### PR TITLE
Only build `windows` on Windows, CI naming

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,19 +25,23 @@ jobs:
         override: true
         components: rustfmt, clippy
 
-    - uses: actions-rs/cargo@v1
+    - name: cargo build
+      uses: actions-rs/cargo@v1
       with:
         command: build
         args: --verbose
-    - uses: actions-rs/cargo@v1
+    - name: cargo test
+      uses: actions-rs/cargo@v1
       with:
         command: test
         args: --verbose
-    - uses: actions-rs/cargo@v1
+    - name: cargo fmt
+      uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: --all -- --check
-    - uses: actions-rs/cargo@v1
+    - name: cargo clippy
+      uses: actions-rs/cargo@v1
       with:
         command: clippy
         args: -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = "0.8.3"
 once_cell = "1.7.2"
 env_logger = "0.9"
 
-[build-dependencies]
+[target.'cfg(windows)'.build-dependencies]
 windows = "0.9.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Howdy! I work on [Nushell](https://github.com/nushell/nushell) and we use `trash-rs` - thanks very much for making it :)

This PR has 2 small improvements:
- Only use the `windows` crate as a build dependency on Windows.
  - This dramatically speeds up building `trash-rs` on Linux; it goes from ~9s to ~4s using `cargo build --jobs 2` (the `--jobs 2` is to simulate a GitHub test runner with only 2 cores) on my machine
- Add names to the various `cargo *` CI steps, makes them easier to identify in the GitHub Actions UI

Let me know what you think; happy to break those into separate PRs if you prefer.