### PR TITLE
derive Clone for TrashItem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ where
 ///
 /// A trash item can be a file or folder or any other object that the target
 /// operating system allows to put into the trash.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TrashItem {
     /// A system specific identifier of the item in the trash.
     ///


### PR DESCRIPTION
The use case I have is that I need to restore slices from a `Vec`, which are references but but `restore_all` takes owned `TrashItem`s, so cloning is needed. I think it is better to change the api to use references but this is simpler. Having `Clone` available is also generally useful.