### PR TITLE
Keep detailed file system error for users using **freedesktop**

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -1,5 +1,5 @@
 //! This implementation will manage the trash according to the Freedesktop Trash specification,
-//! version 1.0 found at https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html
+//! version 1.0 found at <https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html>
 //!
 //! Most -if not all- Linux based desktop operating systems implement the Trash according to this specification.
 //! In other words: I looked, but I could not find any Linux based desktop OS that used anything else than the
@@ -1033,5 +1033,5 @@ mod tests {
 
 /// Converts a file system error to a crate `Error`
 fn fsys_err_to_unknown<P: AsRef<Path>>(path: P, orig: std::io::Error) -> Error {
-    Error::Unknown { description: format!("Path: '{:?}'. Message: {}", path.as_ref(), orig) }
+    Error::FileSystem { path: path.as_ref().to_owned(), kind: orig.kind() }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,20 @@ pub enum Error {
         description: String,
     },
 
+    /// **freedesktop only**
+    ///
+    /// Error coming from file system
+    #[cfg(all(
+        unix,
+        not(target_os = "macos"),
+        not(target_os = "ios"),
+        not(target_os = "android")
+    ))]
+    FileSystem {
+        path: PathBuf,
+        kind: std::io::ErrorKind,
+    },
+
     /// One of the target items was a root folder.
     /// If a list of items are requested to be removed by a single function call (e.g. `delete_all`)
     /// and this error is returned, then it's guaranteed that none of the items is removed.


### PR DESCRIPTION
I think formatting the file system error into `Error::Unknown` is inconvenient. It is more appropriate to separate it from `Unknown` because it has a structured body.