### PR TITLE
Update `windows` crate to `0.44`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ once_cell = "1.7.2"
 once_cell = "1.7.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.43.0", features = [
+windows = { version = "0.44.0", features = [
     "Win32_Foundation",
     "Win32_System_Com_StructuredStorage",
     "Win32_UI_Shell_PropertiesSystem",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ edition = "2018"
 use_try_shorthand = true
 use_field_init_shorthand = true
 use_small_heuristics = "Max"
+max_width = 120

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,12 +143,7 @@ pub enum Error {
     /// **freedesktop only**
     ///
     /// Error coming from file system
-    #[cfg(all(
-        unix,
-        not(target_os = "macos"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    ))]
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
     FileSystem {
         path: PathBuf,
         kind: std::io::ErrorKind,
@@ -211,12 +206,12 @@ pub enum Error {
 }
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Error during a `trash` operation: {:?}", self)
+        write!(f, "Error during a `trash` operation: {self:?}")
     }
 }
 impl error::Error for Error {}
 pub fn into_unknown<E: std::fmt::Display>(err: E) -> Error {
-    Error::Unknown { description: format!("{}", err) }
+    Error::Unknown { description: format!("{err}") }
 }
 
 pub(crate) fn canonicalize_paths<I, T>(paths: I) -> Result<Vec<PathBuf>, Error>
@@ -229,17 +224,15 @@ where
         .map(|x| {
             let target_ref = x.as_ref();
             let target = if target_ref.is_relative() {
-                let curr_dir = current_dir().map_err(|_| Error::CouldNotAccess {
-                    target: "[Current working directory]".into(),
-                })?;
+                let curr_dir = current_dir()
+                    .map_err(|_| Error::CouldNotAccess { target: "[Current working directory]".into() })?;
                 curr_dir.join(target_ref)
             } else {
                 target_ref.to_owned()
             };
             let parent = target.parent().ok_or(Error::TargetedRoot)?;
-            let canonical_parent = parent
-                .canonicalize()
-                .map_err(|_| Error::CanonicalizePath { original: parent.to_owned() })?;
+            let canonical_parent =
+                parent.canonicalize().map_err(|_| Error::CanonicalizePath { original: parent.to_owned() })?;
             if let Some(file_name) = target.file_name() {
                 Ok(canonical_parent.join(file_name))
             } else {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -98,7 +98,7 @@ fn delete_using_file_mgr(full_paths: Vec<String>) -> Result<(), Error> {
         let url: id = unsafe { msg_send![url_cls, fileURLWithPath:string.ptr] };
         if url == nil {
             return Err(Error::Unknown {
-                description: format!("Failed to convert a path to an NSURL. Path: '{}'", path),
+                description: format!("Failed to convert a path to an NSURL. Path: '{path}'"),
             });
         }
         trace!("Finished fileURLWithPath");
@@ -121,9 +121,8 @@ fn delete_using_file_mgr(full_paths: Vec<String>) -> Result<(), Error> {
             if error == nil {
                 return Err(Error::Unknown {
                     description: format!(
-                        "While deleting '{}', `trashItemAtURL` returned with failure but no error was specified.",
-                        path
-                    )
+                        "While deleting '{path}', `trashItemAtURL` returned with failure but no error was specified.",
+                    ),
                 });
             }
             let code: isize = unsafe { msg_send![error, code] };
@@ -131,8 +130,7 @@ fn delete_using_file_mgr(full_paths: Vec<String>) -> Result<(), Error> {
             let domain = unsafe { ns_string_to_rust(domain)? };
             return Err(Error::Unknown {
                 description: format!(
-                    "While deleting '{}', `trashItemAtURL` failed, code: {}, domain: {}",
-                    path, code, domain
+                    "While deleting '{path}', `trashItemAtURL` failed, code: {code}, domain: {domain}",
                 ),
             });
         }
@@ -145,12 +143,8 @@ fn delete_using_finder(full_paths: Vec<String>) -> Result<(), Error> {
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
-    let posix_files = full_paths
-        .into_iter()
-        .map(|p| format!("POSIX file \"{}\"", p))
-        .collect::<Vec<String>>()
-        .join(", ");
-    let script = format!("tell application \"Finder\" to delete {{ {} }}", posix_files);
+    let posix_files = full_paths.into_iter().map(|p| format!("POSIX file \"{p}\"")).collect::<Vec<String>>().join(", ");
+    let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];
     command.args(argv);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,8 +45,7 @@ mod os_limited {
         let file_name_prefix = get_unique_name();
         let batches: usize = 2;
         let files_per_batch: usize = 3;
-        let names: Vec<_> =
-            (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for _ in 0..batches {
             for path in names.iter() {
                 File::create(path).unwrap();
@@ -54,10 +53,8 @@ mod os_limited {
             trash::delete_all(&names).unwrap();
         }
         let items = trash::os_limited::list().unwrap();
-        let items: HashMap<_, Vec<_>> = items
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .fold(HashMap::new(), |mut map, x| {
+        let items: HashMap<_, Vec<_>> =
+            items.into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).fold(HashMap::new(), |mut map, x| {
                 match map.entry(x.name.clone()) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().push(x);
@@ -113,8 +110,7 @@ mod os_limited {
         let file_name_prefix = get_unique_name();
         let batches: usize = 2;
         let files_per_batch: usize = 3;
-        let names: Vec<_> =
-            (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for _ in 0..batches {
             for path in names.iter() {
                 File::create(path).unwrap();
@@ -123,18 +119,12 @@ mod os_limited {
         }
 
         // Collect it because we need the exact number of items gathered.
-        let targets: Vec<_> = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .collect();
+        let targets: Vec<_> =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
         assert_eq!(targets.len(), batches * files_per_batch);
         trash::os_limited::purge_all(targets).unwrap();
-        let remaining = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .count();
+        let remaining =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).count();
         assert_eq!(remaining, 0);
     }
 
@@ -144,26 +134,19 @@ mod os_limited {
         init_logging();
         let file_name_prefix = get_unique_name();
         let file_count: usize = 3;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
         trash::delete_all(&names).unwrap();
 
         // Collect it because we need the exact number of items gathered.
-        let targets: Vec<_> = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .collect();
+        let targets: Vec<_> =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
         assert_eq!(targets.len(), file_count);
         trash::os_limited::restore_all(targets).unwrap();
-        let remaining = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .count();
+        let remaining =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).count();
         assert_eq!(remaining, 0);
 
         // They are not in the trash anymore but they should be at their original location
@@ -187,8 +170,7 @@ mod os_limited {
         let file_name_prefix = get_unique_name();
         let file_count: usize = 3;
         let collision_remaining = file_count - 1;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
@@ -196,11 +178,8 @@ mod os_limited {
         for path in names.iter().skip(file_count - collision_remaining) {
             File::create(path).unwrap();
         }
-        let mut targets: Vec<_> = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .collect();
+        let mut targets: Vec<_> =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
         targets.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(targets.len(), file_count);
         let remaining_count;
@@ -224,9 +203,7 @@ mod os_limited {
                 for path in names.iter() {
                     std::fs::remove_file(path).ok();
                 }
-                panic!(
-                "restore_all was expected to return `trash::ErrorKind::RestoreCollision` but did not."
-            );
+                panic!("restore_all was expected to return `trash::ErrorKind::RestoreCollision` but did not.");
             }
         }
         let remaining = trash::os_limited::list()
@@ -248,8 +225,7 @@ mod os_limited {
         init_logging();
         let file_name_prefix = get_unique_name();
         let file_count: usize = 4;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
@@ -259,11 +235,8 @@ mod os_limited {
         File::create(twin_name).unwrap();
         trash::delete(&twin_name).unwrap();
 
-        let mut targets: Vec<_> = trash::os_limited::list()
-            .unwrap()
-            .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
-            .collect();
+        let mut targets: Vec<_> =
+            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
         targets.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(targets.len(), file_count + 1); // plus one for one of the twins
         match trash::os_limited::restore_all(targets) {
@@ -271,9 +244,7 @@ mod os_limited {
                 assert_eq!(path.file_name().unwrap().to_str().unwrap(), twin_name);
                 trash::os_limited::purge_all(items).unwrap();
             }
-            _ => panic!(
-                "restore_all was expected to return `trash::ErrorKind::RestoreTwins` but did not."
-            ),
+            _ => panic!("restore_all was expected to return `trash::ErrorKind::RestoreTwins` but did not."),
         }
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,10 +14,8 @@ const PSGUID_DISPLACED: GUID =
     GUID::from_values(0x9b174b33, 0x40ff, 0x11d2, [0xa2, 0x7e, 0x00, 0xc0, 0x4f, 0xc3, 0x8, 0x71]);
 const PID_DISPLACED_FROM: u32 = 2;
 const PID_DISPLACED_DATE: u32 = 3;
-const SCID_ORIGINAL_LOCATION: PROPERTYKEY =
-    PROPERTYKEY { fmtid: PSGUID_DISPLACED, pid: PID_DISPLACED_FROM };
-const SCID_DATE_DELETED: PROPERTYKEY =
-    PROPERTYKEY { fmtid: PSGUID_DISPLACED, pid: PID_DISPLACED_DATE };
+const SCID_ORIGINAL_LOCATION: PROPERTYKEY = PROPERTYKEY { fmtid: PSGUID_DISPLACED, pid: PID_DISPLACED_FROM };
+const SCID_DATE_DELETED: PROPERTYKEY = PROPERTYKEY { fmtid: PSGUID_DISPLACED, pid: PID_DISPLACED_DATE };
 
 const FOF_SILENT: u32 = 0x0004;
 const FOF_NOCONFIRMATION: u32 = 0x0010;
@@ -31,7 +29,7 @@ const FOFX_EARLYFAILURE: u32 = 0x00100000;
 
 impl From<windows::core::Error> for Error {
     fn from(err: windows::core::Error) -> Error {
-        Error::Unknown { description: format!("windows error: {}", err) }
+        Error::Unknown { description: format!("windows error: {err}") }
     }
 }
 
@@ -47,8 +45,7 @@ impl TrashContext {
     pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
         ensure_com_initialized();
         unsafe {
-            let pfo: IFileOperation =
-                CoCreateInstance(&FileOperation as *const _, None, CLSCTX_ALL).unwrap();
+            let pfo: IFileOperation = CoCreateInstance(&FileOperation as *const _, None, CLSCTX_ALL).unwrap();
 
             pfo.SetOperationFlags(FOF_NO_UI | FOF_ALLOWUNDO | FOF_WANTNUKEWARNING)?;
 
@@ -62,8 +59,7 @@ impl TrashContext {
                     &wide_path_container[0..]
                 };
 
-                let shi: IShellItem =
-                    SHCreateItemFromParsingName(PCWSTR(wide_path_slice.as_ptr()), None)?;
+                let shi: IShellItem = SHCreateItemFromParsingName(PCWSTR(wide_path_slice.as_ptr()), None)?;
 
                 pfo.DeleteItem(&shi, None)?;
             }
@@ -104,9 +100,7 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
 
                     item_vec.push(TrashItem {
                         id,
-                        name: name
-                            .into_string()
-                            .map_err(|original| Error::ConvertOsString { original })?,
+                        name: name.into_string().map_err(|original| Error::ConvertOsString { original })?,
                         original_parent: PathBuf::from(original_location),
                         time_deleted: date_deleted,
                     });
@@ -173,12 +167,9 @@ where
             let trash_item: IShellItem = SHCreateItemFromParsingName(parsing_name, None)?;
             let parent_path_wide: Vec<_> =
                 item.original_parent.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
-            let orig_folder_shi: IShellItem =
-                SHCreateItemFromParsingName(PCWSTR(parent_path_wide.as_ptr()), None)?;
-            let name_wstr: Vec<_> = AsRef::<OsStr>::as_ref(&item.name)
-                .encode_wide()
-                .chain(std::iter::once(0))
-                .collect();
+            let orig_folder_shi: IShellItem = SHCreateItemFromParsingName(PCWSTR(parent_path_wide.as_ptr()), None)?;
+            let name_wstr: Vec<_> =
+                AsRef::<OsStr>::as_ref(&item.name).encode_wide().chain(std::iter::once(0)).collect();
 
             pfo.MoveItem(&trash_item, &orig_folder_shi, PCWSTR(name_wstr.as_ptr()), None)?;
         }
@@ -222,10 +213,7 @@ struct CoInitializer {}
 impl CoInitializer {
     fn new() -> CoInitializer {
         //let first = INITIALIZER_THREAD_COUNT.fetch_add(1, Ordering::SeqCst) == 0;
-        #[cfg(all(
-            not(feature = "coinit_multithreaded"),
-            not(feature = "coinit_apartmentthreaded")
-        ))]
+        #[cfg(all(not(feature = "coinit_multithreaded"), not(feature = "coinit_apartmentthreaded")))]
         {
             0 = "THIS IS AN ERROR ON PURPOSE. Either the `coinit_multithreaded` or the `coinit_apartmentthreaded` feature must be specified";
         }

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -63,7 +63,7 @@ fn test_delete_all() {
     trace!("Started test_delete_all");
     let count: usize = 3;
 
-    let paths: Vec<_> = (0..count).map(|i| format!("test_file_to_delete_{}", i)).collect();
+    let paths: Vec<_> = (0..count).map(|i| format!("test_file_to_delete_{i}")).collect();
     for path in paths.iter() {
         File::create(path).unwrap();
     }
@@ -148,6 +148,6 @@ fn recursive_file_deletion() {
     File::create(dir1.join("same-name")).unwrap();
     File::create(dir2.join("same-name")).unwrap();
 
-    trash::delete(&parent_dir).unwrap();
+    trash::delete(parent_dir).unwrap();
     assert!(!parent_dir.exists());
 }


### PR DESCRIPTION
Most recent version published on crates.io.

On github there already exists a tag for `0.45` with minor changes to `windows-sys` but not `windows`.
https://github.com/microsoft/windows-rs/releases/tag/0.45.0

According to my limited understanding this change should not affect the semver major version.
Motivated by attempt to reduce dependency duplication in [nushell](https://github.com/nushell/nushell/pull/7911/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e)
