### PR TITLE
Make recent `clippy` happy

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -11,7 +11,7 @@ fn main() {
     for name in the_others.iter() {
         File::create(name).unwrap();
     }
-    trash::delete_all(&the_others).unwrap();
+    trash::delete_all(the_others).unwrap();
     for name in the_others.iter() {
         assert!(File::open(name).is_err());
     }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -25,5 +25,5 @@ fn main() {
         })
         .count();
 
-    println!("There are {} old items in your trash.", old_count);
+    println!("There are {old_count} old items in your trash.");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,12 +211,12 @@ pub enum Error {
 }
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Error during a `trash` operation: {:?}", self)
+        write!(f, "Error during a `trash` operation: {self:?}")
     }
 }
 impl error::Error for Error {}
 pub fn into_unknown<E: std::fmt::Display>(err: E) -> Error {
-    Error::Unknown { description: format!("{}", err) }
+    Error::Unknown { description: format!("{err}") }
 }
 
 pub(crate) fn canonicalize_paths<I, T>(paths: I) -> Result<Vec<PathBuf>, Error>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,7 +46,7 @@ mod os_limited {
         let batches: usize = 2;
         let files_per_batch: usize = 3;
         let names: Vec<_> =
-            (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+            (0..files_per_batch).map(|i| format!("{file_name_prefix}#{i}")).collect();
         for _ in 0..batches {
             for path in names.iter() {
                 File::create(path).unwrap();
@@ -91,7 +91,7 @@ mod os_limited {
 
         // Let's try to purge all the items we just created but ignore any errors
         // as this test should succeed as long as `list` works properly.
-        let _ = trash::os_limited::purge_all(items.into_iter().map(|(_name, item)| item).flatten());
+        let _ = trash::os_limited::purge_all(items.into_values().flatten());
     }
 
     #[test]
@@ -114,7 +114,7 @@ mod os_limited {
         let batches: usize = 2;
         let files_per_batch: usize = 3;
         let names: Vec<_> =
-            (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+            (0..files_per_batch).map(|i| format!("{file_name_prefix}#{i}")).collect();
         for _ in 0..batches {
             for path in names.iter() {
                 File::create(path).unwrap();
@@ -144,8 +144,7 @@ mod os_limited {
         init_logging();
         let file_name_prefix = get_unique_name();
         let file_count: usize = 3;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{file_name_prefix}#{i}")).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
@@ -187,8 +186,7 @@ mod os_limited {
         let file_name_prefix = get_unique_name();
         let file_count: usize = 3;
         let collision_remaining = file_count - 1;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{file_name_prefix}#{i}")).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
@@ -203,8 +201,7 @@ mod os_limited {
             .collect();
         targets.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(targets.len(), file_count);
-        let remaining_count;
-        match trash::os_limited::restore_all(targets) {
+        let remaining_count = match trash::os_limited::restore_all(targets) {
             Err(trash::Error::RestoreCollision { remaining_items, .. }) => {
                 let contains = |v: &Vec<trash::TrashItem>, name: &String| {
                     for curr in v.iter() {
@@ -218,7 +215,7 @@ mod os_limited {
                 for path in names.iter().filter(|filename| !contains(&remaining_items, filename)) {
                     assert!(File::open(path).is_ok());
                 }
-                remaining_count = remaining_items.len();
+                remaining_items.len()
             }
             _ => {
                 for path in names.iter() {
@@ -228,7 +225,7 @@ mod os_limited {
                 "restore_all was expected to return `trash::ErrorKind::RestoreCollision` but did not."
             );
             }
-        }
+        };
         let remaining = trash::os_limited::list()
             .unwrap()
             .into_iter()
@@ -248,8 +245,7 @@ mod os_limited {
         init_logging();
         let file_name_prefix = get_unique_name();
         let file_count: usize = 4;
-        let names: Vec<_> =
-            (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<_> = (0..file_count).map(|i| format!("{file_name_prefix}#{i}")).collect();
         for path in names.iter() {
             File::create(path).unwrap();
         }
@@ -257,7 +253,7 @@ mod os_limited {
 
         let twin_name = &names[1];
         File::create(twin_name).unwrap();
-        trash::delete(&twin_name).unwrap();
+        trash::delete(twin_name).unwrap();
 
         let mut targets: Vec<_> = trash::os_limited::list()
             .unwrap()

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -31,7 +31,7 @@ const FOFX_EARLYFAILURE: u32 = 0x00100000;
 
 impl From<windows::core::Error> for Error {
     fn from(err: windows::core::Error) -> Error {
-        Error::Unknown { description: format!("windows error: {}", err) }
+        Error::Unknown { description: format!("windows error: {err}") }
     }
 }
 

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -63,7 +63,7 @@ fn test_delete_all() {
     trace!("Started test_delete_all");
     let count: usize = 3;
 
-    let paths: Vec<_> = (0..count).map(|i| format!("test_file_to_delete_{}", i)).collect();
+    let paths: Vec<_> = (0..count).map(|i| format!("test_file_to_delete_{i}")).collect();
     for path in paths.iter() {
         File::create(path).unwrap();
     }
@@ -148,6 +148,6 @@ fn recursive_file_deletion() {
     File::create(dir1.join("same-name")).unwrap();
     File::create(dir2.join("same-name")).unwrap();
 
-    trash::delete(&parent_dir).unwrap();
+    trash::delete(parent_dir).unwrap();
     assert!(!parent_dir.exists());
 }


### PR DESCRIPTION
With Rust `1.67` clippy complains about `clippy::uninlined_format_args`

See failures in #60
