### PR TITLE
New API: borrow `TrashItem`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-
-
 [package]
 name = "trash"
 version = "3.0.1"
@@ -21,6 +19,7 @@ coinit_speed_over_memory = []
 
 [dependencies]
 log = "0.4"
+thiserror = "1.0"
 
 [dev-dependencies]
 serial_test = "0.6.0"

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -213,9 +213,9 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
     Ok(result)
 }
 
-pub fn purge_all<I>(items: I) -> Result<(), Error>
+pub fn purge_all<'a, I>(items: I) -> Result<(), Error>
 where
-    I: IntoIterator<Item = TrashItem>,
+    I: IntoIterator<Item = &'a TrashItem>,
 {
     for item in items.into_iter() {
         // When purging an item the "in-trash" filename must be parsed from the trashinfo filename
@@ -787,7 +787,7 @@ mod tests {
 
         // Let's try to purge all the items we just created but ignore any errors
         // as this test should succeed as long as `list` works properly.
-        let _ = purge_all(items.into_iter().map(|(_name, item)| item).flatten());
+        let _ = purge_all(items.values().flatten());
     }
 
     //////////////////////////////////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use std::path::{Path, PathBuf};
 use log::trace;
 
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;
 
 #[cfg(target_os = "windows")]
 #[path = "windows.rs"]
@@ -138,15 +138,15 @@ pub enum Error {
     /// One of the target items was a root folder.
     /// If a list of items are requested to be removed by a single function call (e.g. `delete_all`)
     /// and this error is returned, then it's guaranteed that none of the items is removed.
-    #[error("Root directory inoperable")]
+    #[error("root directory is inoperable")]
     TargetedRoot,
 
     /// The `target` does not exist or the process has insufficient permissions to access it.
-    #[error("{target}: Not accessible")]
+    #[error("unable to access '{target}'")]
     CouldNotAccess { target: String },
 
     /// Error while canonicalizing path.
-    #[error("{original:?}: Canonicalization failed")]
+    #[error("fail to canonicalize path {original:?}")]
     CanonicalizePath {
         /// Path that triggered the error.
         original: PathBuf,
@@ -155,7 +155,7 @@ pub enum Error {
     /// Error while converting an [`OsString`] to a [`String`].
     ///
     /// This may also happen when converting a [`Path`] or [`PathBuf`] to an [`OsString`].
-    #[error("{original:?}: Conversion failed")]
+    #[error("fail at converting {original:?} to `String`")]
     ConvertOsString {
         /// The string that was attempted to be converted.
         original: OsString,
@@ -174,13 +174,13 @@ pub enum Error {
     /// `path`: The path of the file that's blocking the trash item from being restored.
     ///
     /// `restored`: The count of successfully restored items.
-    #[error("{path:?}: Already exists")]
+    #[error("{path:?} have already existed")]
     RestoreCollision { path: PathBuf, restored: usize },
 
     /// This sort of error is returned when multiple items with the same `original_path` were
     /// requested to be restored. These items are referred to as twins here. If there are twins
     /// among the items, then none of the items are restored.
-    #[error("{0:?}: Same paths for twins")]
+    #[error("multiple items have same path {0:?}")]
     RestoreTwins(
         /// The `original_path` of the twins.
         PathBuf,
@@ -190,9 +190,8 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
 
-    #[error("{description}")]
-    Unknown { description: String },
-
+    #[error("{0}")]
+    Unknown(String),
 }
 
 pub(crate) fn canonicalize_paths<I, T>(paths: I) -> Result<Vec<PathBuf>, Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,11 +341,11 @@ pub mod os_limited {
     /// // There's no need to `collect` it otherwise.
     /// let selected: Vec<_> = list().unwrap().into_iter().filter(|x| x.name == filename).collect();
     /// assert_eq!(selected.len(), 1);
-    /// purge_all(selected).unwrap();
+    /// purge_all(&selected).unwrap();
     /// ```
-    pub fn purge_all<I>(items: I) -> Result<(), Error>
+    pub fn purge_all<'a, I>(items: I) -> Result<(), Error>
     where
-        I: IntoIterator<Item = TrashItem>,
+        I: IntoIterator<Item = &'a TrashItem>,
     {
         platform::purge_all(items)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -88,7 +88,7 @@ mod os_limited {
 
         // Let's try to purge all the items we just created but ignore any errors
         // as this test should succeed as long as `list` works properly.
-        let _ = trash::os_limited::purge_all(items.into_iter().map(|(_name, item)| item).flatten());
+        let _ = trash::os_limited::purge_all(items.values().flatten());
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod os_limited {
         let targets: Vec<_> =
             trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
         assert_eq!(targets.len(), batches * files_per_batch);
-        trash::os_limited::purge_all(targets).unwrap();
+        trash::os_limited::purge_all(&targets).unwrap();
         let remaining =
             trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).count();
         assert_eq!(remaining, 0);
@@ -212,7 +212,7 @@ mod os_limited {
             .filter(|x| x.name.starts_with(&file_name_prefix))
             .collect::<Vec<_>>();
         assert_eq!(remaining.len(), remaining_count);
-        trash::os_limited::purge_all(remaining).unwrap();
+        trash::os_limited::purge_all(&remaining).unwrap();
         for path in names.iter() {
             // This will obviously fail on the items that both didn't collide and weren't restored.
             std::fs::remove_file(path).ok();
@@ -242,7 +242,7 @@ mod os_limited {
         match trash::os_limited::restore_all(targets) {
             Err(trash::Error::RestoreTwins { path, items }) => {
                 assert_eq!(path.file_name().unwrap().to_str().unwrap(), twin_name);
-                trash::os_limited::purge_all(items).unwrap();
+                trash::os_limited::purge_all(&items).unwrap();
             }
             _ => panic!("restore_all was expected to return `trash::ErrorKind::RestoreTwins` but did not."),
         }


### PR DESCRIPTION
This PR brings the following new features:
- `restore_all` and `purge_all` take `&TrashItem` as parameters instead of taking ownership. It helps us avoid cloning `TrashItem`s when we want to keep the ownership of them after restoring or purging.

- Correspondingly, the `Error::RestoreCollision` now contains field `restored: usize` which means how many items are restored before collision. Anyone who wants to continue restoring can skip `restored + 1` items on the passed iterator.

> However, I don't understand why the doc tells me *One should not assume any relationship between the order that the items were supplied and the list of remaining items* but I passed the unit test for `RestoreCollison`.

- Error is constructed by `thiserror` now. The reason for using `thiserror` is there are too many I/O Result in the codes. `#[error(transparent)] Io(#[from] io::Error)` makes the error handling more convenient and reasonable.

Sadly, this PR only works on Linux. I can't setup a virtual machine of other platforms temporarily. If this PR is verified to be sensible, I wish someone could complete the work of other platforms.