### PR TITLE
Add method to export trash path (issue #38)

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -49,6 +49,21 @@ impl TrashContext {
         }
         Ok(())
     }
+
+    /// Retrieves the path of the Trash directory.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::fs::File;
+    /// use trash::{ delete, trash_path };
+    /// File::create("mv_to_trash").unwrap();
+    /// delete("mv_to_trash").unwrap();
+    /// assert!(trash_path().unwrap().join("files").join("mv_to_trash").exists())
+    /// ```
+    pub fn trash_path(&self) -> Result<PathBuf, Error> {
+        home_trash()
+    }
 }
 
 pub fn list() -> Result<Vec<TrashItem>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,13 @@ impl TrashContext {
     }
 }
 
+/// Convenience method for `DEFAULT_TRASH_CTX.trash_path()`
+///
+/// See: [`TrashContext::trash_path`](TrashContext::trash_path)
+pub fn trash_path() -> Result<PathBuf, Error> {
+    DEFAULT_TRASH_CTX.trash_path()
+}
+
 /// Convenience method for `DEFAULT_TRASH_CTX.delete()`.
 ///
 /// See: [`TrashContext::delete`](TrashContext::delete)

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use log::trace;
 
 use serial_test::serial;
-use trash::{delete, delete_all};
+use trash::{delete, delete_all, trash_path};
 
 mod util {
     use std::sync::atomic::{AtomicI64, Ordering};
@@ -38,6 +38,20 @@ fn test_delete_file() {
     delete(&path).unwrap();
     assert!(File::open(&path).is_err());
     trace!("Finished test_delete_file");
+}
+
+#[test]
+#[serial]
+fn test_trash_path() {
+    init_logging();
+    trace!("Started test_trash_path");
+
+    let path = PathBuf::from(get_unique_name());
+    File::create(&path).unwrap();
+
+    delete(&path).unwrap();
+    assert!(trash_path().unwrap().join("files").join(path).exists());
+    trace!("Finished test_trash_path");
 }
 
 #[test]


### PR DESCRIPTION
### Description

Up to now, there is no way of knowing where the files are going when removed. Of course you could use [this specification](https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html), but doing that would require to duplicate the code for getting the trash directory on every user.

### Possible solution

To fix this, public method `thrash_path()` has been added to the public API along with tests and documentation. This methods returns the same Trash directory that the crate uses for removing files.

Fixes issue #38.