### PR TITLE
fix: disallow empty paths from being deleted. (#73)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ serial_test = "0.6.0"
 chrono = "0.4.9"
 rand = "0.8.3"
 once_cell = "1.7.2"
-env_logger = "0.9"
+env_logger = "0.10.0"
+tempfile = "3.6.0"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,9 @@ where
     paths
         .map(|x| {
             let target_ref = x.as_ref();
+            if target_ref.as_os_str().is_empty() {
+                return Err(Error::CanonicalizePath { original: target_ref.to_owned() });
+            }
             let target = if target_ref.is_relative() {
                 let curr_dir = current_dir()
                     .map_err(|_| Error::CouldNotAccess { target: "[Current working directory]".into() })?;

--- a/tests/isolated.rs
+++ b/tests/isolated.rs
@@ -1,0 +1,11 @@
+use trash::delete;
+
+#[test]
+fn delete_with_empty_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::env::set_current_dir(tmp.path()).unwrap();
+    assert_eq!(
+        delete("").unwrap_err().to_string(),
+        "Error during a `trash` operation: CanonicalizePath { original: \"\" }"
+    );
+}


### PR DESCRIPTION
Previously passing "" for deletion wuold delete the current working directory
as it would canonicalize any input path without validating the path is non-empty.
