### PR TITLE
Added fs_time_deleted attribute to TrashItem

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -203,7 +203,13 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
                     }
                     let time_deleted_v = time_deleted.unwrap_or(-1);
                     let time_deleted_u64 = time_deleted_v as u64;
-                    result.push(TrashItem { id, name, original_parent, time_deleted: time_deleted.unwrap_or(-1), fs_time_deleted: time_deleted_u64});
+                    result.push(TrashItem {
+                        id,
+                        name,
+                        original_parent,
+                        time_deleted: time_deleted.unwrap_or(-1),
+                        fs_time_deleted: time_deleted_u64,
+                    });
                 } else {
                     warn!("Could not determine the original parent folder of the trash item. (The `Path` field is probably missing from the info file.) The info file path is: '{:?}'", info_path);
                 }

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -201,7 +201,9 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
                     if time_deleted.is_none() {
                         warn!("Could not determine the deletion time of the trash item. (The `DeletionDate` field is probably missing from the info file.) The info file path is: '{:?}'", info_path);
                     }
-                    result.push(TrashItem { id, name, original_parent, time_deleted: time_deleted.unwrap_or(-1) });
+                    let time_deleted_v = time_deleted.unwrap_or(-1);
+                    let time_deleted_u64 = time_deleted_v as u64;
+                    result.push(TrashItem { id, name, original_parent, time_deleted: time_deleted.unwrap_or(-1), fs_time_deleted: time_deleted_u64});
                 } else {
                     warn!("Could not determine the original parent folder of the trash item. (The `Path` field is probably missing from the info file.) The info file path is: '{:?}'", info_path);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,6 +275,7 @@ pub struct TrashItem {
     /// moment the file was deleted.
     /// Without the "chrono" feature, this will be a negative number on linux only.
     pub time_deleted: i64,
+    pub fs_time_deleted: u64,
 }
 
 impl TrashItem {


### PR DESCRIPTION
The attribute allows to access the filesystem timeformat without converting back and forth