### PR TITLE
`purge_all` allows passing in items' ownership or reference

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -7,6 +7,7 @@
 //!
 
 use std::{
+    borrow::Borrow,
     collections::HashSet,
     fs::{create_dir_all, File, OpenOptions},
     io::{BufRead, BufReader, Write},
@@ -225,12 +226,13 @@ fn virtually_exists(path: &Path) -> std::io::Result<bool> {
 
 pub fn purge_all<I>(items: I) -> Result<(), Error>
 where
-    I: IntoIterator<Item = TrashItem>,
+    I: IntoIterator,
+    <I as IntoIterator>::Item: Borrow<TrashItem>,
 {
     for item in items.into_iter() {
         // When purging an item the "in-trash" filename must be parsed from the trashinfo filename
         // which is the filename in the `id` field.
-        let info_file = &item.id;
+        let info_file = &item.borrow().id;
 
         // A bunch of unwraps here. This is fine because if any of these fail that means
         // that either there's a bug in this code or the target system didn't follow

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ pub mod os_limited {
     //! Linux or other Freedesktop Trash compliant environment.
 
     use std::{
+        borrow::Borrow,
         collections::HashSet,
         hash::{Hash, Hasher},
     };
@@ -332,10 +333,13 @@ pub mod os_limited {
     ///
     /// # Example
     ///
+    /// Taking items' ownership:
+    ///
     /// ```
     /// use std::fs::File;
     /// use trash::{delete, os_limited::{list, purge_all}};
-    /// let filename = "trash-purge_all-example";
+    ///
+    /// let filename = "trash-purge_all-example-ownership";
     /// File::create(filename).unwrap();
     /// delete(filename).unwrap();
     /// // Collect the filtered list just so that we can make sure there's exactly one element.
@@ -344,9 +348,25 @@ pub mod os_limited {
     /// assert_eq!(selected.len(), 1);
     /// purge_all(selected).unwrap();
     /// ```
+    ///
+    /// Taking items' reference:
+    ///
+    /// ```
+    /// use std::fs::File;
+    /// use trash::{delete, os_limited::{list, purge_all}};
+    ///
+    /// let filename = "trash-purge_all-example-reference";
+    /// File::create(filename).unwrap();
+    /// delete(filename).unwrap();
+    /// let mut selected = list().unwrap();
+    /// selected.retain(|x| x.name == filename);
+    /// assert_eq!(selected.len(), 1);
+    /// purge_all(&selected).unwrap();
+    /// ```
     pub fn purge_all<I>(items: I) -> Result<(), Error>
     where
-        I: IntoIterator<Item = TrashItem>,
+        I: IntoIterator,
+        <I as IntoIterator>::Item: Borrow<TrashItem>,
     {
         platform::purge_all(items)
     }


### PR DESCRIPTION
`purge_all` implementation for https://github.com/Byron/trash-rs/issues/54 .

The reason why accepting owned items even though we can take only references is compatibility. Refer to https://github.com/Byron/trash-rs/pull/65#issuecomment-1665062549 .

---

This PR **is not fully compatible**. It would cause the scene whose type is ambiguous fails compiling, see below:

```rust
fn purge_empty() {
    // error!
    trash::os_limited::purge_all(vec![]).unwrap();
}
```

You need to declare the type:

```rust
fn purge_empty() {
    trash::os_limited::purge_all::<Vec<trash::TrashItem>>(vec![]).unwrap();
}
```

But I believe the scenes are extremely rare in practice.