### PR TITLE
NetBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "trash"
-version = "3.0.6"
+version = "3.0.7"
 authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,22 +24,22 @@ log = "0.4"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }
-chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
-rand = "0.8.3"
-once_cell = "1.7.2"
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+rand = "0.8.5"
+once_cell = "1.18.0"
 env_logger = "0.10.0"
-tempfile = "3.6.0"
+tempfile = "3.8.0"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.7"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
-chrono = { version = "0.4.9", optional = true, default-features = false, features = ["clock"] }
-libc = "0.2.65"
-scopeguard = "1.0.0"
-url = "2.1.0"
-once_cell = "1.7.2"
+chrono = { version = "0.4.31", optional = true, default-features = false, features = ["clock"] }
+libc = "0.2.149"
+scopeguard = "1.2.0"
+url = "2.4.1"
+once_cell = "1.18.0"
 
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 once_cell = "1.7.2"
@@ -50,4 +50,4 @@ windows = { version = "0.44.0", features = [
     "Win32_System_Com_StructuredStorage",
     "Win32_UI_Shell_PropertiesSystem",
 ] }
-scopeguard = "1.0.0"
+scopeguard = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 description = "A library for moving files and folders to the Recycle Bin"
 keywords = ["remove", "trash", "rubbish", "recycle", "bin"]
 repository = "https://github.com/ArturKovacs/trash"
-edition = "2018"
+edition = "2021"
 include = ["src/**/*", "LICENSE.txt", "README.md", "CHANGELOG.md", "build.rs"]
 
 [features]

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -702,12 +702,12 @@ fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
             std::str::from_utf8(buf).ok()
         }
     }
-    let mut fs_infos: *mut libc::statfs = std::ptr::null_mut();
+    let mut fs_infos: *mut libc::statvfs = std::ptr::null_mut();
     let count = unsafe { libc::getmntinfo(&mut fs_infos, libc::MNT_WAIT) };
     if count < 1 {
         return Ok(Vec::new());
     }
-    let fs_infos: &[libc::statfs] = unsafe { std::slice::from_raw_parts(fs_infos as _, count as _) };
+    let fs_infos: &[libc::statvfs] = unsafe { std::slice::from_raw_parts(fs_infos as _, count as _) };
 
     let mut result = Vec::new();
     for fs_info in fs_infos {


### PR DESCRIPTION
A step closer to fix https://github.com/Byron/trash-rs/issues/83

@Byron don't know if it's feasible with a partial fix but, the remaining issue needs to be fixed in `libc` crate.

### Tasks

* [x] CI setup to test NetBSD, see [this configuration](https://github.com/woelper/oculante/blob/e6e54253ff7de22601678eb6aaebe3f84a02c7ca/.github/workflows/netbsd_minimal.yml) as potential guide
* [x] use `statvfs` calls
* [x] workaround for lack of `libc::getmntinfo` or `libc::get_mount_points`


> [!WARNING]
> CI doesn't currently test that target, and it being green falsely suggests that this PR works as is.