### PR TITLE
draft: Check trash path

### DIFF
--- a/examples/delete.rs
+++ b/examples/delete.rs
@@ -2,6 +2,11 @@ use std::env;
 use std::path::PathBuf;
 use trash::{delete_all, Error};
 
+#[cfg(target_os = "macos")]
+fn main() {
+    println!("This example is not available on macOS");
+}
+
 #[cfg(any(
     target_os = "windows",
     all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))

--- a/examples/delete.rs
+++ b/examples/delete.rs
@@ -1,0 +1,14 @@
+use std::env;
+use std::path::PathBuf;
+use trash::{delete_all, Error};
+
+#[cfg(any(
+    target_os = "windows",
+    all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))
+))]
+fn main() -> Result<(), Error> {
+    let args: Vec<PathBuf> = env::args().skip(1).map(String::into).collect();
+    delete_all(args)?;
+
+    Ok(())
+}

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -36,8 +36,8 @@ impl TrashContext {
 
         full_paths
             .iter()
-            .map(|path| {
-                let topdir = get_topdir_for_path(&path, &mount_points);
+            .try_for_each(|path| {
+                let topdir = get_topdir_for_path(path, &mount_points);
 
                 if topdir == home_topdir {
                     if path.starts_with(home_trash.as_path()) {
@@ -54,8 +54,7 @@ impl TrashContext {
                 }
 
                 Ok(())
-            })
-            .collect::<Result<(), _>>()?;
+            })?;
 
         for path in full_paths {
             debug!("Deleting {:?}", path);

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -761,7 +761,7 @@ mod tests {
         env,
         ffi::OsString,
         fmt,
-        fs::{File, remove_dir_all},
+        fs::{remove_dir_all, File},
         os::unix,
         path::{Path, PathBuf},
         process::Command,

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -34,27 +34,25 @@ impl TrashContext {
         debug!("The home topdir is {:?}", home_topdir);
         let uid = unsafe { libc::getuid() };
 
-        full_paths
-            .iter()
-            .try_for_each(|path| {
-                let topdir = get_topdir_for_path(path, &mount_points);
+        full_paths.iter().try_for_each(|path| {
+            let topdir = get_topdir_for_path(path, &mount_points);
 
-                if topdir == home_topdir {
-                    if path.starts_with(home_trash.as_path()) {
-                        return Err(Error::TargetedTrash);
-                    }
-                } else {
-                    return execute_on_mounted_trash_folders(uid, topdir, true, true, |trash_path| {
-                        if path.starts_with(trash_path.as_path()) {
-                            Err(Error::TargetedTrash)
-                        } else {
-                            Ok(())
-                        }
-                    });
+            if topdir == home_topdir {
+                if path.starts_with(home_trash.as_path()) {
+                    return Err(Error::TargetedTrash);
                 }
+            } else {
+                return execute_on_mounted_trash_folders(uid, topdir, true, true, |trash_path| {
+                    if path.starts_with(trash_path.as_path()) {
+                        Err(Error::TargetedTrash)
+                    } else {
+                        Ok(())
+                    }
+                });
+            }
 
-                Ok(())
-            })?;
+            Ok(())
+        })?;
 
         for path in full_paths {
             debug!("Deleting {:?}", path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ where
 }
 
 /// Provides information about an error.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     Unknown {
         description: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,11 @@ pub enum Error {
     /// and this error is returned, then it's guaranteed that none of the items is removed.
     TargetedRoot,
 
+    /// One of the target items was a trash folder or inside a trash folder.
+    /// If a list of items are requested to be removed by a single function call (e.g. `delete_all`)
+    /// and this error is returned, then it's guaranteed that none of the items is removed.
+    TargetedTrash,
+
     /// The `target` does not exist or the process has insufficient permissions to access it.
     CouldNotAccess {
         target: String,


### PR DESCRIPTION
## Issue
The current implementation allows the removal of a trash folder with trash-rs

## Fix
This seems rather weird so i added a check for it.

## Note
I also added an example that simply passes all args to delete_all. I made it anyway so might as well push it.

This is marked as a draft because I'm not sure whether my code meets your quality.