### PR TITLE
Unbreak build on DragonFly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ scopeguard = "1.2.0"
 url = "2.4.1"
 once_cell = "1.18.0"
 
-[target.'cfg(any(target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+[target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 once_cell = "1.7.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -678,7 +678,7 @@ fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
     Ok(result)
 }
 
-#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
     use once_cell::sync::Lazy;
     use std::sync::Mutex;


### PR DESCRIPTION
Found downstream via [czkawka](https://sting.dragonflybsd.org/dports/logs/sysutils___czkawka.log). This is a blind fix as I don't use DragonFly but one can set up CI via [dragonflybsd-vm](https://github.com/vmactions/dragonflybsd-vm).

DragonFly forked from FreeBSD ~20 years ago, so [getmntinfo(3)](https://man.dragonflybsd.org/?command=getmntinfo&section=3) API is the same but the implementation lacks recent changes like https://github.com/freebsd/freebsd-src/commit/5a28df2e1353 and https://github.com/freebsd/freebsd-src/commit/34ed0c63c878. DragonFly unlike FreeBSD also has [getmntvinfo(3)](https://man.dragonflybsd.org/?command=getmntvinfo&section=3) which uses `statvfs` similar to NetBSD [getmntinfo(3)](https://man.netbsd.org/getmntinfo.3) but NetBSD lacks getmntvinfo(3) (thus `statvfs`-only).

For simplicity let's use FreeBSD codepath. `libc` crate doesn't expose `getmntvinfo`, anyway.
