### PR TITLE
More precise file system error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,15 +207,7 @@ impl fmt::Display for Error {
         write!(f, "Error during a `trash` operation: {self:?}")
     }
 }
-impl error::Error for Error {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
-            Self::FileSystem { path: _, source: e } => e.source(),
-            _ => None,
-        }
-    }
-}
+impl error::Error for Error {}
 pub fn into_unknown<E: std::fmt::Display>(err: E) -> Error {
     Error::Unknown { description: format!("{err}") }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,15 @@ impl fmt::Display for Error {
         write!(f, "Error during a `trash` operation: {self:?}")
     }
 }
-impl error::Error for Error {}
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+            Self::FileSystem { path: _, source: e } => e.source(),
+            _ => None,
+        }
+    }
+}
 pub fn into_unknown<E: std::fmt::Display>(err: E) -> Error {
     Error::Unknown { description: format!("{err}") }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub enum Error {
     #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
     FileSystem {
         path: PathBuf,
-        kind: std::io::ErrorKind,
+        source: std::io::Error,
     },
 
     /// One of the target items was a root folder.
@@ -207,7 +207,15 @@ impl fmt::Display for Error {
         write!(f, "Error during a `trash` operation: {self:?}")
     }
 }
-impl error::Error for Error {}
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+            Self::FileSystem { path: _, source: e } => e.source(),
+            _ => None,
+        }
+    }
+}
 pub fn into_unknown<E: std::fmt::Display>(err: E) -> Error {
     Error::Unknown { description: format!("{err}") }
 }


### PR DESCRIPTION
I think the file system (freedesktop only) error provided in the current version is too imprecise. So I make the following improvements:

- Any errors coming from `std::fs` will be returned with the path using by the `fs` function.
- Change the `std::io::ErrorKind` in `Error::FileSystem` to `std::io::Error`

I have to apologize for my immaturity; I thought `ErrorKind` is enough to be the error source so I took it in.