### PR TITLE
Add metadata function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,9 @@ once_cell = "1.7.2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.44.0", features = [
     "Win32_Foundation",
+    "Win32_Storage_EnhancedStorage",
     "Win32_System_Com_StructuredStorage",
+    "Win32_System_SystemServices",
     "Win32_UI_Shell_PropertiesSystem",
 ] }
 scopeguard = "1.2.0"

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -1,0 +1,20 @@
+#[cfg(not(any(
+    target_os = "windows",
+    all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))
+)))]
+fn main() {
+    println!("This is currently only supported on Windows, Linux, and other Freedesktop.org compliant OSes");
+}
+
+#[cfg(any(
+    target_os = "windows",
+    all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))
+))]
+fn main() {
+    let trash_items = trash::os_limited::list().unwrap();
+
+    for item in trash_items {
+        let metadata = trash::os_limited::metadata(&item).unwrap();
+        println!("{:?}: {:?}", item, metadata);
+    }
+}

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -808,6 +808,18 @@ fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
     Ok(result)
 }
 
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+)))]
+fn get_mount_points() -> Result<Vec<MountPoint>, Error> {
+    // On platforms that don't have support yet, simply return no mount points
+    Ok(Vec::new())
+}
+
 #[cfg(test)]
 mod tests {
     use serial_test::serial;

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -232,7 +232,7 @@ pub fn metadata(item: &TrashItem) -> Result<TrashItemMetadata, Error> {
     } else {
         TrashItemSize::Bytes(metadata.len())
     };
-    Ok(TrashItemMetadata { is_dir, size })
+    Ok(TrashItemMetadata { size })
 }
 
 /// The path points to:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,15 @@ impl Hash for TrashItem {
     }
 }
 
+/// Metadata about a [`TrashItem`]
+#[derive(Debug, Clone)]
+pub struct TrashItemMetadata {
+    /// True if the [`TrashItem`] is a directory, false if it is a file
+    pub is_dir: bool,
+    /// Number of entries for directories, number of bytes for files
+    pub size: u64,
+}
+
 #[cfg(any(
     target_os = "windows",
     all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android"))
@@ -318,7 +327,7 @@ pub mod os_limited {
         hash::{Hash, Hasher},
     };
 
-    use super::{platform, Error, TrashItem};
+    use super::{platform, Error, TrashItem, TrashItemMetadata};
 
     /// Returns all [`TrashItem`]s that are currently in the trash.
     ///
@@ -333,6 +342,21 @@ pub mod os_limited {
     /// ```
     pub fn list() -> Result<Vec<TrashItem>, Error> {
         platform::list()
+    }
+
+    /// Returns the [`TrashItemMetadata`] for a [`TrashItem`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use trash::os_limited::{list, metadata};
+    /// let trash_items = list().unwrap();
+    /// for item in trash_items {
+    ///     println!("{:#?}", metadata(&item).unwrap());
+    /// }
+    /// ```
+    pub fn metadata(item: &TrashItem) -> Result<TrashItemMetadata, Error> {
+        platform::metadata(item)
     }
 
     /// Deletes all the provided [`TrashItem`]s permanently.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ impl Hash for TrashItem {
 }
 
 /// Size of a [`TrashItem`] in bytes or entries
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum TrashItemSize {
     /// Number of bytes in a file
     Bytes(u64),
@@ -313,12 +313,28 @@ pub enum TrashItemSize {
     Entries(usize),
 }
 
+impl TrashItemSize {
+    /// The size of a file in bytes, if this item is a file.
+    pub fn size(&self) -> Option<u64> {
+        match self {
+            TrashItemSize::Bytes(s) => Some(*s),
+            TrashItemSize::Entries(_) => None,
+        }
+    }
+
+    /// The amount of entries in the directory, if this is a directory.
+    pub fn entries(&self) -> Option<usize> {
+        match self {
+            TrashItemSize::Bytes(_) => None,
+            TrashItemSize::Entries(e) => Some(*e),
+        }
+    }
+}
+
 /// Metadata about a [`TrashItem`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct TrashItemMetadata {
-    /// True if the [`TrashItem`] is a directory, false if it is a file
-    pub is_dir: bool,
-    /// The size of the item, as a [`TrashItemSize`] enum
+    /// The size of the item, depending on whether or not it is a directory.
     pub size: TrashItemSize,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,13 +304,22 @@ impl Hash for TrashItem {
     }
 }
 
+/// Size of a [`TrashItem`] in bytes or entries
+#[derive(Debug, Clone)]
+pub enum TrashItemSize {
+    /// Number of bytes in a file
+    Bytes(u64),
+    /// Number of entries in a directory, non-recursive
+    Entries(usize),
+}
+
 /// Metadata about a [`TrashItem`]
 #[derive(Debug, Clone)]
 pub struct TrashItemMetadata {
     /// True if the [`TrashItem`] is a directory, false if it is a file
     pub is_dir: bool,
-    /// Number of entries for directories, number of bytes for files
-    pub size: u64,
+    /// The size of the item, as a [`TrashItemSize`] enum
+    pub size: TrashItemSize,
 }
 
 #[cfg(any(

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use crate::{Error, TrashContext, TrashItem};
+use crate::{Error, TrashContext, TrashItem, TrashItemMetadata};
 use std::{
     borrow::Borrow,
     ffi::{c_void, OsStr, OsString},
@@ -7,7 +7,10 @@ use std::{
     path::PathBuf,
 };
 use windows::core::{Interface, GUID, PCWSTR, PWSTR};
-use windows::Win32::{Foundation::*, System::Com::*, UI::Shell::PropertiesSystem::*, UI::Shell::*};
+use windows::Win32::{
+    Foundation::*, Storage::EnhancedStorage::*, System::Com::*, System::SystemServices::*,
+    UI::Shell::PropertiesSystem::*, UI::Shell::*,
+};
 
 ///////////////////////////////////////////////////////////////////////////
 // These don't have bindings in windows-rs for some reason
@@ -70,7 +73,7 @@ impl TrashContext {
         }
     }
 
-    /// Removes all files and folder paths recursively.  
+    /// Removes all files and folder paths recursively.
     pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
         let mut collection = Vec::new();
         traverse_paths_recursively(full_paths, &mut collection)?;
@@ -121,6 +124,43 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
         }
 
         Ok(item_vec)
+    }
+}
+
+pub fn metadata(item: &TrashItem) -> Result<TrashItemMetadata, Error> {
+    ensure_com_initialized();
+    unsafe {
+        let id_as_wide: Vec<u16> = item.id.encode_wide().chain(std::iter::once(0)).collect();
+        let parsing_name = PCWSTR(id_as_wide.as_ptr());
+        let item: IShellItem = SHCreateItemFromParsingName(parsing_name, None)?;
+        let is_dir = item.GetAttributes(SFGAO_FOLDER)? == SFGAO_FOLDER;
+        let size = if is_dir {
+            let pesi: IEnumShellItems = item.BindToHandler(None, &BHID_EnumItems)?;
+            let mut size = 0;
+            loop {
+                let mut fetched_count: u32 = 0;
+                let mut arr = [None];
+                pesi.Next(&mut arr, Some(&mut fetched_count as *mut u32))?;
+
+                if fetched_count == 0 {
+                    break;
+                }
+
+                match &arr[0] {
+                    Some(_item) => {
+                        size += 1;
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+            size
+        } else {
+            let item2: IShellItem2 = item.cast()?;
+            item2.GetUInt64(&PKEY_Size)?
+        };
+        Ok(TrashItemMetadata { is_dir, size })
     }
 }
 


### PR DESCRIPTION
Resolves #94, adds a metadata function to get the type of the item (file or folder) and the size (in bytes for files or entries for folders). This is implemented for Freedesktop platforms and Windows