### PR TITLE
Choose the longest valid mount point

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -82,8 +82,8 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
     // Get all mount-points and attempt to find a trash folder in each adding them to the SET of
     // trash folders when found one.
     let uid = unsafe { libc::getuid() };
-    let mount_points = get_sorted_mount_points()?;
-    for mount in &mount_points {
+    let sorted_mount_points = get_sorted_mount_points()?;
+    for mount in &sorted_mount_points {
         execute_on_mounted_trash_folders(uid, &mount.mnt_dir, false, false, |trash_path| {
             trash_folders.insert(trash_path);
             Ok(())
@@ -98,7 +98,7 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
     let mut result = Vec::new();
     for folder in &trash_folders {
         // Read the info files for every file
-        let top_dir = get_first_topdir_containing_path(folder, &mount_points);
+        let top_dir = get_first_topdir_containing_path(folder, &sorted_mount_points);
         let info_folder = folder.join("info");
         if !info_folder.is_dir() {
             warn!("The path {:?} did not point to a directory, skipping this trash folder.", info_folder);
@@ -639,7 +639,6 @@ struct MountPoint {
     _mnt_fsname: String,
 }
 
-#[cfg(target_os = "linux")]
 fn get_sorted_mount_points() -> Result<Vec<MountPoint>, Error> {
     // Returns longest mount points first
     let mut mount_points = get_mount_points()?;

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -629,7 +629,7 @@ fn get_topdir_for_path<'a>(path: &Path, mnt_points: &'a [MountPoint]) -> &'a Pat
             // If there is a /run mount and a /run/media/user mount, we want to prioritize the
             // longest
             let mount_length = &mount_point.mnt_dir.to_str().unwrap().len();
-            if topdir == None || mount_length > &path_length {
+            if topdir.is_none() || mount_length > &path_length {
                 path_length = *mount_length;
                 topdir = Some(&mount_point.mnt_dir);
             }

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -642,7 +642,7 @@ struct MountPoint {
 fn get_sorted_mount_points() -> Result<Vec<MountPoint>, Error> {
     // Returns longest mount points first
     let mut mount_points = get_mount_points()?;
-    mount_points.sort_by(|a, b| b.mnt_dir.as_os_str().as_bytes().len().cmp(&a.mnt_dir.as_os_str().as_bytes().len()));
+    mount_points.sort_unstable_by(|a, b| b.mnt_dir.as_os_str().as_bytes().len().cmp(&a.mnt_dir.as_os_str().as_bytes().len()));
     Ok(mount_points)
 }
 

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -642,7 +642,8 @@ struct MountPoint {
 fn get_sorted_mount_points() -> Result<Vec<MountPoint>, Error> {
     // Returns longest mount points first
     let mut mount_points = get_mount_points()?;
-    mount_points.sort_unstable_by(|a, b| b.mnt_dir.as_os_str().as_bytes().len().cmp(&a.mnt_dir.as_os_str().as_bytes().len()));
+    mount_points
+        .sort_unstable_by(|a, b| b.mnt_dir.as_os_str().as_bytes().len().cmp(&a.mnt_dir.as_os_str().as_bytes().len()));
     Ok(mount_points)
 }
 


### PR DESCRIPTION
If the user has a drive mounted at `/run` and `/run/media/test`, and they are trashing a file `/run/media/test/remove-me`, depending on the order the mount point iterates through, it could incorrectly choose `/run` as the mount point, leading to a failed trash.

This simple pull request takes the longest valid mount point and uses that for the trash directory. This should prevent the issue above.

Note: I have not done too much rust development, so I'm not entirely sure that this is the simplest way to solve this. Please let me know if you see of anything that can be improved. 

Related: #57 