### PR TITLE
List valid trash bin paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,7 @@ pub mod os_limited {
         borrow::Borrow,
         collections::HashSet,
         hash::{Hash, Hasher},
+        path::PathBuf,
     };
 
     use super::{platform, Error, TrashItem, TrashItemMetadata};
@@ -372,6 +373,23 @@ pub mod os_limited {
     /// ```
     pub fn list() -> Result<Vec<TrashItem>, Error> {
         platform::list()
+    }
+
+    /// Returns all valid trash bins.
+    ///
+    /// Valid trash folders include the user's personal "home trash" as well as designated trash
+    /// bins across mount points. Some, or all of these, may not exist or be invalid in some way.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use trash::os_limited::trash_folders;
+    /// let trash_bins = trash_folders()?;
+    /// println!("{trash_bins:#?}");
+    /// # Ok::<(), trash::Error>(())
+    /// ```
+    pub fn trash_folders() -> Result<HashSet<PathBuf>, Error> {
+        platform::trash_folders()
     }
 
     /// Returns the [`TrashItemMetadata`] for a [`TrashItem`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,6 @@ pub mod os_limited {
         borrow::Borrow,
         collections::HashSet,
         hash::{Hash, Hasher},
-        path::PathBuf,
     };
 
     use super::{platform, Error, TrashItem, TrashItemMetadata};
@@ -391,7 +390,7 @@ pub mod os_limited {
     /// # Ok::<(), trash::Error>(())
     /// ```
     #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
-    pub fn trash_folders() -> Result<HashSet<PathBuf>, Error> {
+    pub fn trash_folders() -> Result<HashSet<std::path::PathBuf>, Error> {
         platform::trash_folders()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ pub mod os_limited {
         platform::list()
     }
 
-    /// Returns all valid trash bins.
+    /// Returns all valid trash bins on supported Unix platforms.
     ///
     /// Valid trash folders include the user's personal "home trash" as well as designated trash
     /// bins across mount points. Some, or all of these, may not exist or be invalid in some way.
@@ -383,11 +383,14 @@ pub mod os_limited {
     /// # Example
     ///
     /// ```
+    /// # #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))] {
     /// use trash::os_limited::trash_folders;
     /// let trash_bins = trash_folders()?;
     /// println!("{trash_bins:#?}");
+    /// # }
     /// # Ok::<(), trash::Error>(())
     /// ```
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
     pub fn trash_folders() -> Result<HashSet<PathBuf>, Error> {
         platform::trash_folders()
     }


### PR DESCRIPTION
This is a small refactor to support listing Freedesktop compliant trash bins.

Enumerating trash bins, which may reside across mount points or be invalid in some way, is useful for end users who need the paths themselves rather than the items in the trash.