### PR TITLE
fix: Support non-Unicode paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ coinit_speed_over_memory = []
 
 [dependencies]
 log = "0.4"
-urlencoding = "2.1.3"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }
@@ -47,7 +46,7 @@ chrono = { version = "0.4.31", optional = true, default-features = false, featur
 ] }
 libc = "0.2.149"
 scopeguard = "1.2.0"
-url = "2.4.1"
+urlencoding = "2.1.3"
 once_cell = "1.18.0"
 
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ coinit_speed_over_memory = []
 
 [dependencies]
 log = "0.4"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -450,16 +450,13 @@ fn move_to_trash(
     loop {
         appendage += 1;
         let in_trash_name: Cow<'_, OsStr> = if appendage > 1 {
-            // Length of the digits plus the dot
-            let appen_len: usize = appendage.checked_ilog10().unwrap_or_default() as usize + 1;
-            let mut trash_name = OsString::with_capacity(filename.len() + appen_len);
-            trash_name.push(filename);
-            trash_name.push(".");
-            trash_name.push(appendage.to_string());
+            let mut trash_name = filename.to_owned();
+            trash_name.push(format!(".{appendage}"));
             trash_name.into()
         } else {
             filename.into()
         };
+        // Length of name + length of '.trashinfo'
         let mut info_name = OsString::with_capacity(in_trash_name.len() + 10);
         info_name.push(&in_trash_name);
         info_name.push(".trashinfo");
@@ -995,10 +992,10 @@ mod tests {
         let fake = format!("/tmp/{}", get_unique_name());
         let path = decode_uri_path(&fake);
 
-        assert_eq!(fake, path.to_str().expect("Path is valid Unicode"), "Decoded path shouldn't be different");
+        assert_eq!(path.to_str().expect("Path is valid Unicode"), fake, "Decoded path shouldn't be different");
 
         let encoded = encode_uri_path(&path);
-        assert_eq!(fake, encoded, "URL encoded alphanumeric String shouldn't change");
+        assert_eq!(encoded, fake, "URL encoded alphanumeric String shouldn't change");
     }
 
     #[test]
@@ -1020,7 +1017,7 @@ mod tests {
         assert!(fake.to_str().is_none(), "Invalid Unicode cannot be a Rust String");
 
         let path = decode_uri_path(&fake);
-        assert_eq!(fake.as_encoded_bytes(), path.as_os_str().as_encoded_bytes());
+        assert_eq!(path.as_os_str().as_encoded_bytes(), fake.as_encoded_bytes());
 
         // Shouldn't panic
         encode_uri_path(&path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ pub struct TrashItem {
 
     /// The name of the item. For example if the folder '/home/user/New Folder'
     /// was deleted, its `name` is 'New Folder'
-    pub name: String,
+    pub name: OsString,
 
     /// The path to the parent folder of this item before it was put inside the
     /// trash. For example if the folder '/home/user/New Folder' is in the

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -29,6 +29,7 @@ mod os_limited {
     use super::{get_unique_name, init_logging};
     use serial_test::serial;
     use std::collections::{hash_map::Entry, HashMap};
+    use std::ffi::OsString;
     use std::fs::File;
 
     use crate as trash;
@@ -45,7 +46,7 @@ mod os_limited {
         let file_name_prefix = get_unique_name();
         let batches: usize = 2;
         let files_per_batch: usize = 3;
-        let names: Vec<_> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
+        let names: Vec<OsString> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i).into()).collect();
         for _ in 0..batches {
             for path in names.iter() {
                 File::create(path).unwrap();
@@ -53,8 +54,10 @@ mod os_limited {
             trash::delete_all(&names).unwrap();
         }
         let items = trash::os_limited::list().unwrap();
-        let items: HashMap<_, Vec<_>> =
-            items.into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).fold(HashMap::new(), |mut map, x| {
+        let items: HashMap<_, Vec<_>> = items
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .fold(HashMap::new(), |mut map, x| {
                 match map.entry(x.name.clone()) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().push(x);
@@ -82,7 +85,7 @@ mod os_limited {
                         }
                     }
                 }
-                None => panic!("ERROR Could not find '{}' in {:#?}", name, items),
+                None => panic!("ERROR Could not find '{:?}' in {:#?}", name, items),
             }
         }
 
@@ -119,12 +122,18 @@ mod os_limited {
         }
 
         // Collect it because we need the exact number of items gathered.
-        let targets: Vec<_> =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
+        let targets: Vec<_> = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .collect();
         assert_eq!(targets.len(), batches * files_per_batch);
         trash::os_limited::purge_all(targets).unwrap();
-        let remaining =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).count();
+        let remaining = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .count();
         assert_eq!(remaining, 0);
     }
 
@@ -141,12 +150,18 @@ mod os_limited {
         trash::delete_all(&names).unwrap();
 
         // Collect it because we need the exact number of items gathered.
-        let targets: Vec<_> =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
+        let targets: Vec<_> = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .collect();
         assert_eq!(targets.len(), file_count);
         trash::os_limited::restore_all(targets).unwrap();
-        let remaining =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).count();
+        let remaining = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .count();
         assert_eq!(remaining, 0);
 
         // They are not in the trash anymore but they should be at their original location
@@ -178,15 +193,18 @@ mod os_limited {
         for path in names.iter().skip(file_count - collision_remaining) {
             File::create(path).unwrap();
         }
-        let mut targets: Vec<_> =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
+        let mut targets: Vec<_> = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .collect();
         targets.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(targets.len(), file_count);
         let remaining_count = match trash::os_limited::restore_all(targets) {
             Err(trash::Error::RestoreCollision { remaining_items, .. }) => {
                 let contains = |v: &Vec<trash::TrashItem>, name: &String| {
                     for curr in v.iter() {
-                        if *curr.name == *name {
+                        if curr.name.as_encoded_bytes() == name.as_bytes() {
                             return true;
                         }
                     }
@@ -208,7 +226,7 @@ mod os_limited {
         let remaining = trash::os_limited::list()
             .unwrap()
             .into_iter()
-            .filter(|x| x.name.starts_with(&file_name_prefix))
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
             .collect::<Vec<_>>();
         assert_eq!(remaining.len(), remaining_count);
         trash::os_limited::purge_all(remaining).unwrap();
@@ -234,8 +252,11 @@ mod os_limited {
         File::create(twin_name).unwrap();
         trash::delete(twin_name).unwrap();
 
-        let mut targets: Vec<_> =
-            trash::os_limited::list().unwrap().into_iter().filter(|x| x.name.starts_with(&file_name_prefix)).collect();
+        let mut targets: Vec<_> = trash::os_limited::list()
+            .unwrap()
+            .into_iter()
+            .filter(|x| x.name.as_encoded_bytes().starts_with(file_name_prefix.as_bytes()))
+            .collect();
         targets.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(targets.len(), file_count + 1); // plus one for one of the twins
         match trash::os_limited::restore_all(targets) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,6 +31,8 @@ mod os_limited {
     use std::collections::{hash_map::Entry, HashMap};
     use std::ffi::{OsStr, OsString};
     use std::fs::File;
+
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
     use std::os::unix::ffi::OsStringExt;
 
     use crate as trash;
@@ -95,6 +97,7 @@ mod os_limited {
         let _ = trash::os_limited::purge_all(items.iter().flat_map(|(_name, item)| item));
     }
 
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
     #[test]
     #[serial]
     fn list_invalid_utf8() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -97,9 +97,12 @@ pub fn list() -> Result<Vec<TrashItem>, Error> {
                     let original_location = OsString::from_wide(original_location_bstr.as_wide());
                     let date_deleted = get_date_deleted_unix(&item2)?;
 
+                    // NTFS paths are valid Unicode according to this chart:
+                    // https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+                    // Converting a String back to OsString doesn't do extra work
                     item_vec.push(TrashItem {
                         id,
-                        name: name.into_string().map_err(|original| Error::ConvertOsString { original })?,
+                        name: name.into_string().map_err(|original| Error::ConvertOsString { original })?.into(),
                         original_parent: PathBuf::from(original_location),
                         time_deleted: date_deleted,
                     });

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::fs::{create_dir, File};
 use std::path::{Path, PathBuf};
 
@@ -136,6 +137,14 @@ fn create_remove_single_file() {
     File::create(&name).unwrap();
     trash::delete(&name).unwrap();
     assert!(File::open(&name).is_err());
+}
+
+#[test]
+#[serial]
+fn create_remove_single_file_invalid_utf8() {
+    let name = unsafe { OsStr::from_encoded_bytes_unchecked(&[168]) };
+    File::create(name).unwrap();
+    trash::delete(name).unwrap();
 }
 
 #[test]

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -139,6 +139,7 @@ fn create_remove_single_file() {
     assert!(File::open(&name).is_err());
 }
 
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
 #[test]
 #[serial]
 fn create_remove_single_file_invalid_utf8() {


### PR DESCRIPTION
Closes: #105 

I only replaced the `unwrap()`s that directly affect the issue. I also wrote unit tests to verify the new code works.

I switched `url` to a lower level crate, `urlencoding`, because `url` only operated on Rust Strings.

Finally, and probably most concerning, I modified the public API a teensy bit. `TrashItem` 's `name` field is an `OsString` now instead of a `String`. Beyond that, I didn't modify any public APIs.