### PR TITLE
Fix trashing files on Fedora Atomic variants

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -48,6 +48,9 @@ impl TrashContext {
                 // Note that the following function creates the trash folder
                 // and its required subfolders in case they don't exist.
                 move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?;
+            } else if topdir.to_str() == Some("/var/home") && home_topdir.to_str() == Some("/") {
+                debug!("The topdir is '/var/home' but the home_topdir is '/', moving to the home trash anyway.");
+                move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?;
             } else {
                 execute_on_mounted_trash_folders(uid, topdir, true, true, |trash_path| {
                     move_to_trash(&path, trash_path, topdir)


### PR DESCRIPTION
Fixes #112 

Not sure if this is the best/proper way to fix this, but it works on my system:

### Before:
![trash-rs-before](https://github.com/user-attachments/assets/75753cd5-a3ca-4216-91e9-1430334d0d55)

### After (changed trash-rs crate in trashy to use local version):
![trash-rs-after](https://github.com/user-attachments/assets/79344d0a-165d-4dde-ae9b-460b4948e574)
