### PR TITLE
Fail in tests on truncating pre-existing user files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ use trash;
 
 fn main() {
     // Let's create and remove a single file
-    File::create("remove-me").unwrap();
+    File::create_new("remove-me").unwrap();
     trash::delete("remove-me").unwrap();
     assert!(File::open("remove-me").is_err());
 
     // Now let's remove multiple files at once
     let the_others = ["remove-me-too", "dont-forget-about-me-either"];
     for name in the_others.iter() {
-        File::create(name).unwrap();
+        File::create_new(name).unwrap();
     }
     trash::delete_all(&the_others).unwrap();
     for name in the_others.iter() {

--- a/examples/delete_method.rs
+++ b/examples/delete_method.rs
@@ -17,7 +17,7 @@ fn main() {
     trash_ctx.set_delete_method(DeleteMethod::NsFileManager);
 
     let path = "this_file_was_deleted_using_the_ns_file_manager";
-    File::create(path).unwrap();
+    File::create_new(path).unwrap();
     trash_ctx.delete(path).unwrap();
     assert!(File::open(path).is_err());
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,14 +2,14 @@ use std::fs::File;
 
 fn main() {
     // Let's create and remove a single file
-    File::create("remove-me").unwrap();
+    File::create_new("remove-me").unwrap();
     trash::delete("remove-me").unwrap();
     assert!(File::open("remove-me").is_err());
 
     // Now let's remove multiple files at once
     let the_others = ["remove-me-too", "dont-forget-about-me-either"];
     for name in the_others.iter() {
-        File::create(name).unwrap();
+        File::create_new(name).unwrap();
     }
     trash::delete_all(&the_others).unwrap();
     for name in the_others.iter() {

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -896,7 +896,7 @@ mod tests {
         let names: Vec<OsString> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i).into()).collect();
         for _ in 0..batches {
             for path in &names {
-                File::create(path).unwrap();
+                File::create_new(path).unwrap();
             }
             // eprintln!("Deleting {:?}", names);
             let result = delete_all_using_system_program(&names);
@@ -946,7 +946,7 @@ mod tests {
         let symlink_names: Vec<OsString> = names.iter().map(|name| format!("{:?}-symlink", name).into()).collect();
 
         // Test file symbolic link and directory symbolic link
-        File::create(&names[0]).unwrap();
+        File::create_new(&names[0]).unwrap();
         std::fs::create_dir(&names[1]).unwrap();
 
         for (i, (name, symlink)) in names.iter().zip(&symlink_names).enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl TrashContext {
     /// ```
     /// use std::fs::File;
     /// use trash::delete;
-    /// File::create("delete_me").unwrap();
+    /// File::create_new("delete_me").unwrap();
     /// trash::delete("delete_me").unwrap();
     /// assert!(File::open("delete_me").is_err());
     /// ```
@@ -95,8 +95,8 @@ impl TrashContext {
     /// ```
     /// use std::fs::File;
     /// use trash::delete_all;
-    /// File::create("delete_me_1").unwrap();
-    /// File::create("delete_me_2").unwrap();
+    /// File::create_new("delete_me_1").unwrap();
+    /// File::create_new("delete_me_2").unwrap();
     /// delete_all(&["delete_me_1", "delete_me_2"]).unwrap();
     /// assert!(File::open("delete_me_1").is_err());
     /// assert!(File::open("delete_me_2").is_err());
@@ -440,7 +440,7 @@ pub mod os_limited {
     /// use trash::{delete, os_limited::{list, purge_all}};
     ///
     /// let filename = "trash-purge_all-example-ownership";
-    /// File::create(filename).unwrap();
+    /// File::create_new(filename).unwrap();
     /// delete(filename).unwrap();
     /// // Collect the filtered list just so that we can make sure there's exactly one element.
     /// // There's no need to `collect` it otherwise.
@@ -456,7 +456,7 @@ pub mod os_limited {
     /// use trash::{delete, os_limited::{list, purge_all}};
     ///
     /// let filename = "trash-purge_all-example-reference";
-    /// File::create(filename).unwrap();
+    /// File::create_new(filename).unwrap();
     /// delete(filename).unwrap();
     /// let mut selected = list().unwrap();
     /// selected.retain(|x| x.name == filename);
@@ -495,7 +495,7 @@ pub mod os_limited {
     /// use trash::os_limited::{list, restore_all};
     ///
     /// let filename = "trash-restore_all-example";
-    /// File::create(filename).unwrap();
+    /// File::create_new(filename).unwrap();
     /// restore_all(list().unwrap().into_iter().filter(|x| x.name == filename)).unwrap();
     /// std::fs::remove_file(filename).unwrap();
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,13 +522,13 @@ pub mod os_limited {
     {
         // Check for twins here cause that's pretty platform independent.
         struct ItemWrapper<'a>(&'a TrashItem);
-        impl<'a> PartialEq for ItemWrapper<'a> {
+        impl PartialEq for ItemWrapper<'_> {
             fn eq(&self, other: &Self) -> bool {
                 self.0.original_path() == other.0.original_path()
             }
         }
-        impl<'a> Eq for ItemWrapper<'a> {}
-        impl<'a> Hash for ItemWrapper<'a> {
+        impl Eq for ItemWrapper<'_> {}
+        impl Hash for ItemWrapper<'_> {
             fn hash<H: Hasher>(&self, state: &mut H) {
                 self.0.original_path().hash(state);
             }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -153,7 +153,7 @@ mod tests {
         trash_ctx.set_delete_method(DeleteMethod::NsFileManager);
 
         let path = get_unique_name();
-        File::create(&path).unwrap();
+        File::create_new(&path).unwrap();
         trash_ctx.delete(&path).unwrap();
         assert!(File::open(&path).is_err());
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,7 +52,7 @@ mod os_limited {
         let names: Vec<OsString> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i).into()).collect();
         for _ in 0..batches {
             for path in names.iter() {
-                File::create(path).unwrap();
+                File::create_new(path).unwrap();
             }
             trash::delete_all(&names).unwrap();
         }
@@ -104,7 +104,7 @@ mod os_limited {
         let mut name = OsStr::new(&get_unique_name()).to_os_string().into_encoded_bytes();
         name.push(168);
         let name = OsString::from_vec(name);
-        File::create(&name).unwrap();
+        File::create_new(&name).unwrap();
 
         // Delete, list, and remove file with an invalid UTF8 name
         // Listing items is already exhaustively checked above, so this test is mainly concerned
@@ -136,7 +136,7 @@ mod os_limited {
         let names: Vec<_> = (0..files_per_batch).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for _ in 0..batches {
             for path in names.iter() {
-                File::create(path).unwrap();
+                File::create_new(path).unwrap();
             }
             trash::delete_all(&names).unwrap();
         }
@@ -165,7 +165,7 @@ mod os_limited {
         let file_count: usize = 3;
         let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
-            File::create(path).unwrap();
+            File::create_new(path).unwrap();
         }
         trash::delete_all(&names).unwrap();
 
@@ -207,11 +207,11 @@ mod os_limited {
         let collision_remaining = file_count - 1;
         let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
-            File::create(path).unwrap();
+            File::create_new(path).unwrap();
         }
         trash::delete_all(&names).unwrap();
         for path in names.iter().skip(file_count - collision_remaining) {
-            File::create(path).unwrap();
+            File::create_new(path).unwrap();
         }
         let mut targets: Vec<_> = trash::os_limited::list()
             .unwrap()
@@ -264,12 +264,12 @@ mod os_limited {
         let file_count: usize = 4;
         let names: Vec<_> = (0..file_count).map(|i| format!("{}#{}", file_name_prefix, i)).collect();
         for path in names.iter() {
-            File::create(path).unwrap();
+            File::create_new(path).unwrap();
         }
         trash::delete_all(&names).unwrap();
 
         let twin_name = &names[1];
-        File::create(twin_name).unwrap();
+        File::create_new(twin_name).unwrap();
         trash::delete(twin_name).unwrap();
 
         let mut targets: Vec<_> = trash::os_limited::list()

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -34,7 +34,7 @@ fn test_delete_file() {
     trace!("Started test_delete_file");
 
     let path = get_unique_name();
-    File::create(&path).unwrap();
+    File::create_new(&path).unwrap();
 
     delete(&path).unwrap();
     assert!(File::open(&path).is_err());
@@ -49,7 +49,7 @@ fn test_delete_folder() {
 
     let path = PathBuf::from(get_unique_name());
     create_dir(&path).unwrap();
-    File::create(path.join("file_in_folder")).unwrap();
+    File::create_new(path.join("file_in_folder")).unwrap();
 
     assert!(path.exists());
     delete(&path).unwrap();
@@ -66,7 +66,7 @@ fn test_delete_all() {
 
     let paths: Vec<_> = (0..count).map(|i| format!("test_file_to_delete_{i}")).collect();
     for path in paths.iter() {
-        File::create(path).unwrap();
+        File::create_new(path).unwrap();
     }
 
     delete_all(&paths).unwrap();
@@ -94,7 +94,7 @@ mod unix {
         init_logging();
         trace!("Started test_delete_symlink");
         let target_path = get_unique_name();
-        File::create(&target_path).unwrap();
+        File::create_new(&target_path).unwrap();
 
         let link_path = "test_link_to_delete";
         symlink(&target_path, link_path).unwrap();
@@ -112,7 +112,7 @@ mod unix {
         init_logging();
         trace!("Started test_delete_symlink_in_folder");
         let target_path = "test_link_target_for_delete_from_folder";
-        File::create(target_path).unwrap();
+        File::create_new(target_path).unwrap();
 
         let folder = Path::new("test_parent_folder_for_link_to_delete");
         create_dir(folder).unwrap();
@@ -134,7 +134,7 @@ mod unix {
 fn create_remove_single_file() {
     // Let's create and remove a single file
     let name = get_unique_name();
-    File::create(&name).unwrap();
+    File::create_new(&name).unwrap();
     trash::delete(&name).unwrap();
     assert!(File::open(&name).is_err());
 }
@@ -144,7 +144,7 @@ fn create_remove_single_file() {
 #[serial]
 fn create_remove_single_file_invalid_utf8() {
     let name = unsafe { OsStr::from_encoded_bytes_unchecked(&[168]) };
-    File::create(name).unwrap();
+    File::create_new(name).unwrap();
     trash::delete(name).unwrap();
 }
 
@@ -155,8 +155,8 @@ fn recursive_file_deletion() {
     let dir2 = parent_dir.join("dir2");
     std::fs::create_dir_all(&dir1).unwrap();
     std::fs::create_dir_all(&dir2).unwrap();
-    File::create(dir1.join("same-name")).unwrap();
-    File::create(dir2.join("same-name")).unwrap();
+    File::create_new(dir1.join("same-name")).unwrap();
+    File::create_new(dir2.join("same-name")).unwrap();
 
     trash::delete(parent_dir).unwrap();
     assert!(!parent_dir.exists());
@@ -169,7 +169,7 @@ fn recursive_file_with_content_deletion() {
     let dir2 = parent_dir.join("dir2");
     std::fs::create_dir_all(&dir1).unwrap();
     std::fs::create_dir_all(&dir2).unwrap();
-    File::create(dir1.join("same-name")).unwrap();
+    File::create_new(dir1.join("same-name")).unwrap();
     std::fs::write(dir2.join("same-name"), b"some content").unwrap();
 
     trash::delete(parent_dir).unwrap();


### PR DESCRIPTION
`create` has a tiny chance of deleting existing files, so just in case replaced with `create_new`, which fails in this case 

> and will truncate it if it does


not sure what how tests re. lifetimes are related to these changes