### PR TITLE
Add support for binary paths on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ coinit_speed_over_memory = []
 [dependencies]
 log = "0.4"
 percent-encoding = "2.3.1"
+simdutf8 = "0.1.5"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-
-
 [package]
 name = "trash"
 version = "5.2.0"
@@ -29,6 +27,7 @@ rand = "0.8.5"
 once_cell = "1.18.0"
 env_logger = "0.10.0"
 tempfile = "3.8.0"
+defer = "0.2.1"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -40,7 +39,6 @@ objc2-foundation = { version = "0.2.0", features = [
     "NSURL",
 ] }
 percent-encoding = "2.3.1"
-simdutf8 = "0.1.5"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 chrono = { version = "0.4.31", optional = true, default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ coinit_speed_over_memory = []
 
 [dependencies]
 log = "0.4"
+percent-encoding = "2.3.1"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ coinit_speed_over_memory = []
 
 [dependencies]
 log = "0.4"
-percent-encoding = "2.3.1"
-simdutf8 = "0.1.5"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }
@@ -41,6 +39,8 @@ objc2-foundation = { version = "0.2.0", features = [
     "NSString",
     "NSURL",
 ] }
+percent-encoding = "2.3.1"
+simdutf8 = "0.1.5"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 chrono = { version = "0.4.31", optional = true, default-features = false, features = [

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -105,13 +105,17 @@ fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
-    let posix_files = full_paths.into_iter().map(|p| {
-        let path_b = p.as_ref().as_os_str().as_encoded_bytes();
-        match simdutf8::basic::from_utf8(path_b) {
-            Ok(path_utf8) => format!("POSIX file \"{path_utf8}\""), // utf-8 path, use as is
-            Err(_) => format!("POSIX file \"{}\"",&from_utf8_lossy_pc(path_b)), // binary path, %-encode it
-        }
-    }).collect::<Vec<String>>().join(", ");
+    let posix_files = full_paths
+        .into_iter()
+        .map(|p| {
+            let path_b = p.as_ref().as_os_str().as_encoded_bytes();
+            match simdutf8::basic::from_utf8(path_b) {
+                Ok(path_utf8) => format!("POSIX file \"{path_utf8}\""), // utf-8 path, use as is
+                Err(_) => format!("POSIX file \"{}\"", &from_utf8_lossy_pc(path_b)), // binary path, %-encode it
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
     let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -106,7 +106,7 @@ fn delete_using_finder<P: AsRef<Path> + std::fmt::Debug>(full_paths: &[P]) -> Re
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
     let posix_files =
-        full_paths.into_iter().map(|p| format!("POSIX file \"{p:?}\"")).collect::<Vec<String>>().join(", ");
+        full_paths.into_iter().map(|p| format!("POSIX file {p:?}")).collect::<Vec<String>>().join(", ");
     let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -96,12 +96,12 @@ fn delete_using_file_mgr<P:AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
     Ok(())
 }
 
-fn delete_using_finder(full_paths: Vec<String>) -> Result<(), Error> {
+fn delete_using_finder<P:AsRef<Path> + std::fmt::Debug>(full_paths: &[P]) -> Result<(), Error> {
     // AppleScript command to move files (or directories) to Trash looks like
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
-    let posix_files = full_paths.into_iter().map(|p| format!("POSIX file \"{p}\"")).collect::<Vec<String>>().join(", ");
+    let posix_files = full_paths.into_iter().map(|p| format!("POSIX file \"{p:?}\"")).collect::<Vec<String>>().join(", ");
     let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -62,10 +62,9 @@ impl TrashContextExtMacos for TrashContext {
 }
 impl TrashContext {
     pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
-        let full_paths = full_paths.into_iter().map(to_string).collect::<Result<Vec<_>, _>>()?;
         match self.platform_specific.delete_method {
-            DeleteMethod::Finder => delete_using_finder(full_paths),
-            DeleteMethod::NsFileManager => delete_using_file_mgr(full_paths),
+            DeleteMethod::Finder => delete_using_finder(&full_paths),
+            DeleteMethod::NsFileManager => delete_using_file_mgr(&full_paths),
         }
     }
 }
@@ -124,15 +123,6 @@ fn delete_using_finder(full_paths: Vec<String>) -> Result<(), Error> {
         };
     }
     Ok(())
-}
-
-fn to_string<T: Into<OsString>>(str_in: T) -> Result<String, Error> {
-    let os_string = str_in.into();
-    let s = os_string.to_str();
-    match s {
-        Some(s) => Ok(s.to_owned()),
-        None => Err(Error::ConvertOsString { original: os_string }),
-    }
 }
 
 use std::borrow::Cow;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -106,7 +106,7 @@ fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
     let posix_files = full_paths
-        .into_iter()
+        .iter()
         .map(|p| {
             let path_b = p.as_ref().as_os_str().as_encoded_bytes();
             match simdutf8::basic::from_utf8(path_b) {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -178,6 +178,29 @@ mod tests {
         assert!(File::open(&path).is_err());
     }
 
+    // DISABLED: test only works on file systems that support binary paths (not APFS), not sure what CI has
+    // successfully tested on a local HFS usb flash drive
+    #[test]
+    #[serial]
+    fn test_delete_binary_path_with_ns_file_manager() {
+        let parent_fs_supports_binary = "/Volumes/Untitled"; // USB drive that supports non-utf8 paths
+
+        init_logging();
+        let mut trash_ctx = TrashContext::default();
+        trash_ctx.set_delete_method(DeleteMethod::NsFileManager);
+
+        let invalid_utf8 = b"\x80"; // lone continuation byte (128) (invalid utf8)
+        let mut p = PathBuf::new();
+        p.push(parent_fs_supports_binary); // /Volumes/Untitled
+        p.push(get_unique_name());         // /Volumes/Untitled/trash-test-111-0
+        let mut path_invalid = p.clone();
+        path_invalid.set_extension(OsStr::from_bytes(invalid_utf8)); //...trash-test-111-0.\x80 (not push to avoid fail unexisting dir)
+
+        // File::create_new(&path_invalid).unwrap();
+        // trash_ctx.delete(&path_invalid).unwrap();
+        // assert!(File::open(&path_invalid).is_err());
+    }
+
     #[test]
     fn test_path_byte() {
         let invalid_utf8 = b"\x80"; // lone continuation byte (128) (invalid utf8)

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -105,8 +105,7 @@ fn delete_using_finder<P: AsRef<Path> + std::fmt::Debug>(full_paths: &[P]) -> Re
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
-    let posix_files =
-        full_paths.into_iter().map(|p| format!("POSIX file {p:?}")).collect::<Vec<String>>().join(", ");
+    let posix_files = full_paths.into_iter().map(|p| format!("POSIX file {p:?}")).collect::<Vec<String>>().join(", ");
     let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -100,12 +100,18 @@ fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> 
     Ok(())
 }
 
-fn delete_using_finder<P: AsRef<Path> + std::fmt::Debug>(full_paths: &[P]) -> Result<(), Error> {
+fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
     // AppleScript command to move files (or directories) to Trash looks like
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
     let mut command = Command::new("osascript");
-    let posix_files = full_paths.into_iter().map(|p| format!("POSIX file {p:?}")).collect::<Vec<String>>().join(", ");
+    let posix_files = full_paths.into_iter().map(|p| {
+        let path_b = p.as_ref().as_os_str().as_encoded_bytes();
+        match simdutf8::basic::from_utf8(path_b) {
+            Ok(path_utf8) => format!("POSIX file \"{path_utf8}\""), // utf-8 path, use as is
+            Err(_) => format!("POSIX file \"{}\"",&from_utf8_lossy_pc(path_b)), // binary path, %-encode it
+        }
+    }).collect::<Vec<String>>().join(", ");
     let script = format!("tell application \"Finder\" to delete {{ {posix_files} }}");
 
     let argv: Vec<OsString> = vec!["-e".into(), script.into()];

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -223,6 +223,29 @@ mod tests {
         // assert!(File::open(&path_invalid).is_err());
     }
 
+    // DISABLED: test only works on file systems that support binary paths (not APFS), not sure what CI has
+    // successfully tested on a local HFS usb flash drive
+    #[test]
+    #[serial]
+    fn test_delete_binary_path_with_finder() {
+        let parent_fs_supports_binary = "/Volumes/Untitled"; // USB drive that supports non-utf8 paths
+
+        init_logging();
+        let mut trash_ctx = TrashContext::default();
+        trash_ctx.set_delete_method(DeleteMethod::Finder);
+
+        let invalid_utf8 = b"\x80"; // lone continuation byte (128) (invalid utf8)
+        let mut p = PathBuf::new();
+        p.push(parent_fs_supports_binary); // /Volumes/Untitled
+        p.push(get_unique_name()); // /Volumes/Untitled/trash-test-111-0
+        let mut path_invalid = p.clone();
+        path_invalid.set_extension(OsStr::from_bytes(invalid_utf8)); //...trash-test-111-0.\x80 (not push to avoid fail unexisting dir)
+
+        // File::create_new(&path_invalid).unwrap();
+        // trash_ctx.delete(&path_invalid).unwrap();
+        // assert!(File::open(&path_invalid).is_err());
+    }
+
     #[test]
     fn test_path_byte() {
         let invalid_utf8 = b"\x80"; // lone continuation byte (128) (invalid utf8)

--- a/tests/trash.rs
+++ b/tests/trash.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::fs::{create_dir, File};
 use std::path::{Path, PathBuf};
 
@@ -143,6 +142,7 @@ fn create_remove_single_file() {
 #[test]
 #[serial]
 fn create_remove_single_file_invalid_utf8() {
+    use std::ffi::OsStr;
     let name = unsafe { OsStr::from_encoded_bytes_unchecked(&[168]) };
     File::create_new(name).unwrap();
     trash::delete(name).unwrap();


### PR DESCRIPTION
Adds a utf8 conversion step to allow creating valid Mac URLs for its file manager APIs as well as Finder
  - via a fast simd method if everything is fine
  - on fail replaces bytes in invalid utf8 sequences with %-encoded utf8 strings that are valid paths

fixes: https://github.com/Byron/trash-rs/issues/124


Test: the actual delete tests are **DISABLED** since they fails in CI and locally by default since modern APFS doesn't allow binary paths, but I've manually tested on a HFS usb drive that supports it.

Is there an easy way to create some virtual FS during testing so that the test works both locally and in CIs and doesn't require manual intervention?


Also for some reason got the same non-Mac unrelated clippy errors