### PR TITLE
mac: Return trash items that are created by delete 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,13 +53,21 @@ jobs:
           echo "target flag is: ${{ env.TARGET_FLAGS }}"
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
-      - name: cargo test
+      - name: cargo test (excluding main_thread)
         if: ${{ !startsWith(matrix.build, 'netbsd') }}
-        run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }}
+        run: ${{ env.CARGO }} test --verbose ${{ env.TARGET_FLAGS }} -- --skip test_main_thread
 
-      - name: cargo test (without chrono)
+      - name: cargo test (only main_thread)
         if: ${{ !startsWith(matrix.build, 'netbsd') }}
-        run: ${{ env.CARGO }} test --verbose --no-default-features --features coinit_apartmentthreaded ${{ env.TARGET_FLAGS }}
+        run: ${{ env.CARGO }} test test_main_thread --verbose ${{ env.TARGET_FLAGS }} -- --test-threads=1
+
+      - name: cargo test (without chrono, excluding main_thread)
+        if: ${{ !startsWith(matrix.build, 'netbsd') }}
+        run: ${{ env.CARGO }} test --verbose --no-default-features --features coinit_apartmentthreaded ${{ env.TARGET_FLAGS }}  -- --skip test_main_thread
+
+      - name: cargo test (without chrono, only main_thread)
+        if: ${{ !startsWith(matrix.build, 'netbsd') }}
+        run: ${{ env.CARGO }} test test_main_thread --verbose --no-default-features --features coinit_apartmentthreaded ${{ env.TARGET_FLAGS }}  -- --test-threads=1
 
       - name: cargo build
         if: ${{ startsWith(matrix.build, 'netbsd') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ objc2-foundation = { version = "0.2.0", features = [
     "NSURL",
 ] }
 percent-encoding = "2.3.1"
+chrono = { version = "0.4.31", optional = true, default-features = false, features = ["clock",] }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 chrono = { version = "0.4.31", optional = true, default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ env_logger = "0.10.0"
 tempfile = "3.8.0"
 defer = "0.2.1"
 
+[[test]]
+name = "osakit"
+path = "tests/osakit.rs"
+harness = false
+
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }
+libtest-mimic = "0.8.1"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 rand = "0.8.5"
 once_cell = "1.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ objc2-foundation = { version = "0.2.0", features = [
 ] }
 percent-encoding = "2.3.1"
 chrono = { version = "0.4.31", optional = true, default-features = false, features = ["clock",] }
+osakit = "0.2.4"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 chrono = { version = "0.4.31", optional = true, default-features = false, features = [

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -33,12 +33,13 @@ impl PlatformTrashContext {
     }
 }
 impl TrashContext {
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
+    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
         let home_trash = home_trash()?;
         let sorted_mount_points = get_sorted_mount_points()?;
         let home_topdir = home_topdir(&sorted_mount_points)?;
         debug!("The home topdir is {:?}", home_topdir);
         let uid = unsafe { libc::getuid() };
+        let mut items = Vec::with_capacity(full_paths.len());
         for path in full_paths {
             debug!("Deleting {:?}", path);
             let topdir = get_first_topdir_containing_path(&path, &sorted_mount_points);
@@ -47,18 +48,19 @@ impl TrashContext {
                 debug!("The topdir was identical to the home topdir, so moving to the home trash.");
                 // Note that the following function creates the trash folder
                 // and its required subfolders in case they don't exist.
-                move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?;
+                items.push(move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?);
             } else if topdir.to_str() == Some("/var/home") && home_topdir.to_str() == Some("/") {
                 debug!("The topdir is '/var/home' but the home_topdir is '/', moving to the home trash anyway.");
-                move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?;
+                items.push(move_to_trash(path, &home_trash, topdir).map_err(|(p, e)| fs_error(p, e))?);
             } else {
                 execute_on_mounted_trash_folders(uid, topdir, true, true, |trash_path| {
-                    move_to_trash(&path, trash_path, topdir)
+                    items.push(move_to_trash(&path, trash_path, topdir)?);
+                    Ok(())
                 })
                 .map_err(|(p, e)| fs_error(p, e))?;
             }
         }
-        Ok(())
+        Ok(Some(items))
     }
 }
 
@@ -450,7 +452,7 @@ fn move_to_trash(
     src: impl AsRef<Path>,
     trash_folder: impl AsRef<Path>,
     _topdir: impl AsRef<Path>,
-) -> Result<(), FsError> {
+) -> Result<TrashItem, FsError> {
     let src = src.as_ref();
     let trash_folder = trash_folder.as_ref();
     let files_folder = trash_folder.join("files");
@@ -491,6 +493,7 @@ fn move_to_trash(
         info_name.push(".trashinfo");
         let info_file_path = info_folder.join(&info_name);
         let info_result = OpenOptions::new().create_new(true).write(true).open(&info_file_path);
+        let mut time_deleted = -1;
         match info_result {
             Err(error) => {
                 if error.kind() == std::io::ErrorKind::AlreadyExists {
@@ -510,10 +513,12 @@ fn move_to_trash(
                             #[cfg(feature = "chrono")]
                             {
                                 let now = chrono::Local::now();
+                                time_deleted = now.timestamp();
                                 writeln!(file, "DeletionDate={}", now.format("%Y-%m-%dT%H:%M:%S"))
                             }
                             #[cfg(not(feature = "chrono"))]
                             {
+                                time_deleted = -1;
                                 Ok(())
                             }
                         })
@@ -537,12 +542,18 @@ fn move_to_trash(
             }
             Ok(_) => {
                 // We did it!
-                break;
+                return Ok(TrashItem {
+                    id: info_file_path.into(),
+                    name: filename.into(),
+                    original_parent: src
+                        .parent()
+                        .expect("Absolute path to trashed item should have a parent")
+                        .to_path_buf(),
+                    time_deleted,
+                });
             }
         }
     }
-
-    Ok(())
 }
 
 /// An error may mean that a collision was found.

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -33,7 +33,11 @@ impl PlatformTrashContext {
     }
 }
 impl TrashContext {
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>, _with_info: bool) -> Result<Option<Vec<TrashItem>>, Error> {
+    pub(crate) fn delete_all_canonicalized(
+        &self,
+        full_paths: Vec<PathBuf>,
+        _with_info: bool,
+    ) -> Result<Option<Vec<TrashItem>>, Error> {
         let home_trash = home_trash()?;
         let sorted_mount_points = get_sorted_mount_points()?;
         let home_topdir = home_topdir(&sorted_mount_points)?;

--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -33,7 +33,7 @@ impl PlatformTrashContext {
     }
 }
 impl TrashContext {
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
+    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>, _with_info: bool) -> Result<Option<Vec<TrashItem>>, Error> {
         let home_trash = home_trash()?;
         let sorted_mount_points = get_sorted_mount_points()?;
         let home_topdir = home_topdir(&sorted_mount_points)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl TrashContext {
     /// trash::delete("delete_me").unwrap();
     /// assert!(File::open("delete_me").is_err());
     /// ```
-    pub fn delete<T: AsRef<Path>>(&self, path: T) -> Result<(), Error> {
+    pub fn delete<T: AsRef<Path>>(&self, path: T) -> Result<Option<Vec<TrashItem>>, Error> {
         self.delete_all(&[path])
     }
 
@@ -101,7 +101,7 @@ impl TrashContext {
     /// assert!(File::open("delete_me_1").is_err());
     /// assert!(File::open("delete_me_2").is_err());
     /// ```
-    pub fn delete_all<I, T>(&self, paths: I) -> Result<(), Error>
+    pub fn delete_all<I, T>(&self, paths: I) -> Result<Option<Vec<TrashItem>>, Error>
     where
         I: IntoIterator<Item = T>,
         T: AsRef<Path>,
@@ -116,14 +116,14 @@ impl TrashContext {
 /// Convenience method for `DEFAULT_TRASH_CTX.delete()`.
 ///
 /// See: [`TrashContext::delete`](TrashContext::delete)
-pub fn delete<T: AsRef<Path>>(path: T) -> Result<(), Error> {
+pub fn delete<T: AsRef<Path>>(path: T) -> Result<Option<Vec<TrashItem>>, Error> {
     DEFAULT_TRASH_CTX.delete(path)
 }
 
 /// Convenience method for `DEFAULT_TRASH_CTX.delete_all()`.
 ///
 /// See: [`TrashContext::delete_all`](TrashContext::delete_all)
-pub fn delete_all<I, T>(paths: I) -> Result<(), Error>
+pub fn delete_all<I, T>(paths: I) -> Result<Option<Vec<TrashItem>>, Error>
 where
     I: IntoIterator<Item = T>,
     T: AsRef<Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,17 +81,19 @@ impl TrashContext {
     /// trash::delete("delete_me").unwrap();
     /// assert!(File::open("delete_me").is_err());
     /// ```
-    pub fn delete<T: AsRef<Path>>(&self, path: T) ->  Result<Option<Vec<TrashItem>>, Error> {
+    pub fn delete<T: AsRef<Path>>(&self, path: T) -> Result<Option<Vec<TrashItem>>, Error> {
         self.delete_all(&[path])
     }
 
     /// Same as `delete`, but returns `TrashItem` if available.
     pub fn delete_with_info<T: AsRef<Path>>(&self, path: T) -> Result<Option<TrashItem>, Error> {
-        match self.delete_all_with_info(&[path]) { // Result<Option<Vec<TrashItem>>>
-            Ok(maybe_items)     => match maybe_items {
+        match self.delete_all_with_info(&[path]) {
+            // Result<Option<Vec<TrashItem>>>
+            Ok(maybe_items) => match maybe_items {
                 Some(mut items) => Ok(items.pop()), // no need to check that vec.len=2?
-                None            => Ok(None),         },
-            Err(e)              => Err(e),
+                None => Ok(None),
+            },
+            Err(e) => Err(e),
         }
     }
 
@@ -133,7 +135,6 @@ impl TrashContext {
         trace!("Finished canonicalize_paths");
         self.delete_all_canonicalized(full_paths, true)
     }
-
 }
 
 /// Convenience method for `DEFAULT_TRASH_CTX.delete()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,13 @@ impl TrashContext {
     /// trash::delete("delete_me").unwrap();
     /// assert!(File::open("delete_me").is_err());
     /// ```
-    pub fn delete<T: AsRef<Path>>(&self, path: T) -> Result<Option<Vec<TrashItem>>, Error> {
-        self.delete_all(&[path])
+    pub fn delete<T: AsRef<Path>>(&self, path: T) -> Result<Option<TrashItem>, Error> {
+        match self.delete_all(&[path]) { // Result<Option<Vec<TrashItem>>>
+            Ok(maybe_items)     => match maybe_items {
+                Some(mut items) => Ok(items.pop()), // no need to check that vec.len=2?
+                None            => Ok(None),         },
+            Err(e)              => Err(e),
+        }
     }
 
     /// Removes all files/directories specified by the collection of paths provided as an argument.
@@ -116,7 +121,7 @@ impl TrashContext {
 /// Convenience method for `DEFAULT_TRASH_CTX.delete()`.
 ///
 /// See: [`TrashContext::delete`](TrashContext::delete)
-pub fn delete<T: AsRef<Path>>(path: T) -> Result<Option<Vec<TrashItem>>, Error> {
+pub fn delete<T: AsRef<Path>>(path: T) -> Result<Option<TrashItem>, Error> {
     DEFAULT_TRASH_CTX.delete(path)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,9 @@ pub struct TrashItem {
     ///
     /// On Linux it is an absolute path to the `.trashinfo` file associated with
     /// the item.
+    ///
+    /// On macOS it is the string returned by the `.path()` method on the `NSURL` item
+    /// returned by the `trashItemAtURL_resultingItemURL_error` call.
     pub id: OsString,
 
     /// The name of the item. For example if the folder '/home/user/New Folder'
@@ -286,7 +289,11 @@ pub struct TrashItem {
 
     /// The number of non-leap seconds elapsed between the UNIX Epoch and the
     /// moment the file was deleted.
-    /// Without the "chrono" feature, this will be a negative number on linux only.
+    /// Without the "chrono" feature, this will be a negative number on linux/macOS only.
+    /// macOS has the number, but there is no information on how to get it,
+    /// the usual 'kMDItemDateAdded' attribute doesn't exist for files @ trash
+    /// apple.stackexchange.com/questions/437475/how-can-i-find-out-when-a-file-had-been-moved-to-trash
+    /// stackoverflow.com/questions/53341670/access-the-file-date-added-in-terminal
     pub time_deleted: i64,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,9 @@ pub struct TrashItem {
 
     /// The name of the item. For example if the folder '/home/user/New Folder'
     /// was deleted, its `name` is 'New Folder'
+    /// macOS: when trashing with DeleteMethod::Finder, files are passed to Finder in a single batch,
+    /// so if the size of the returned list of trashed paths is different from the list of items we sent
+    /// to trash, we can't match input to output, so will leave this field "" blank
     pub name: OsString,
 
     /// The path to the parent folder of this item before it was put inside the
@@ -327,6 +330,9 @@ pub struct TrashItem {
     ///
     /// To get the full path to the file in its original location use the
     /// `original_path` function.
+    /// macOS: when trashing with DeleteMethod::Finder, files are passed to Finder in a single batch,
+    /// so if the size of the returned list of trashed paths is different from the list of items we sent
+    /// to trash, we can't match input to output, so will leave this field "" blank
     pub original_parent: PathBuf,
 
     /// The number of non-leap seconds elapsed between the UNIX Epoch and the
@@ -334,8 +340,10 @@ pub struct TrashItem {
     /// Without the "chrono" feature, this will be a negative number on linux/macOS only.
     /// macOS has the number, but there is no information on how to get it,
     /// the usual 'kMDItemDateAdded' attribute doesn't exist for files @ trash
-    /// apple.stackexchange.com/questions/437475/how-can-i-find-out-when-a-file-had-been-moved-to-trash
-    /// stackoverflow.com/questions/53341670/access-the-file-date-added-in-terminal
+    ///   apple.stackexchange.com/questions/437475/how-can-i-find-out-when-a-file-had-been-moved-to-trash
+    ///   stackoverflow.com/questions/53341670/access-the-file-date-added-in-terminal
+    /// macOS: when trashing with DeleteMethod::Finder, files are passed to Finder in a single batch, so the timing will be
+    /// set to the time before a batch is trashed and is the same for all files in a batch
     pub time_deleted: i64,
 }
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -66,7 +66,8 @@ pub enum ScriptMethod {
     /// This is the default.
     Cli,
 
-    /// Call into `OSAKit` directly via ObjC-bindings. Faster, but can sometimes to fail to trigger Finder action, stalling for 2 min.
+    /// Call into `OSAKit` directly via ObjC-bindings. Faster, but can sometimes fail to trigger any Finder action,
+    /// stalling for 2 min instead.
     ///
     Osakit,
 }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -112,6 +112,7 @@ fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<Option<Vec<
             });
         } else {
             if let Some(out_nsurl) = out_res_nsurl {
+                #[allow(unused_assignments)]
                 let mut time_deleted = -1;
                 #[cfg(    feature = "chrono") ] {let now = chrono::Local::now(); time_deleted = now.timestamp();}
                 #[cfg(not(feature = "chrono"))] {                                time_deleted = -1;}

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -56,9 +56,9 @@ impl Default for DeleteMethod {
 }
 
 #[derive(Copy, Clone, Debug)]
-/// There are 2 ways to ask Finder to trash files: by calling the `osascript` binary or directly into the `OSAKit` Framework.
-/// The `OSAKit` method should be faster, but it can unexpectedly bug by stalling until the default 2 min timeout expires,
-/// so the default is `osascript`.
+/// There are 2 ways to ask Finder to trash files: ≝1. by calling the `osascript` binary or 2. calling directly into the `OSAKit` Framework.
+/// The `OSAKit` method should be faster, but it MUST be run on the main thread, otherwise it can fail, stalling until the default 2 min
+/// timeout expires.
 ///
 pub enum ScriptMethod {
     /// Spawn a process calling the standalone `osascript` binary to run AppleScript. Slower, but more reliable.
@@ -66,9 +66,7 @@ pub enum ScriptMethod {
     /// This is the default.
     Cli,
 
-    /// Call into `OSAKit` directly via ObjC-bindings. Faster, but can sometimes fail to trigger any Finder action,
-    /// stalling for 2 min instead.
-    ///
+    /// Call into `OSAKit` directly via ObjC-bindings. Faster, but MUST be run on the main thread, or it can fail, stalling for 2 min.
     Osakit,
 }
 impl ScriptMethod {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -108,9 +108,9 @@ fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P], with_info: bool) -> R
         trace!("Calling trashItemAtURL");
         let mut out_res_nsurl: Option<Retained<NSURL>> = None;
         let res = if with_info {
-            unsafe { file_mgr.trashItemAtURL_resultingItemURL_error(&url, None) }
-        } else {
             unsafe { file_mgr.trashItemAtURL_resultingItemURL_error(&url, Some(&mut out_res_nsurl)) }
+        } else {
+            unsafe { file_mgr.trashItemAtURL_resultingItemURL_error(&url, None) }
         };
         trace!("Finished trashItemAtURL");
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -76,14 +76,13 @@ impl TrashContextExtMacos for TrashContext {
 impl TrashContext {
     pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
         match self.platform_specific.delete_method {
-            DeleteMethod::Finder =>  delete_using_finder(&full_paths)?,
-            DeleteMethod::NsFileManager =>  delete_using_file_mgr(&full_paths)?,
+            DeleteMethod::Finder =>  delete_using_finder(&full_paths),
+            DeleteMethod::NsFileManager =>  delete_using_file_mgr(&full_paths),
         }
-        Ok(None)
     }
 }
 
-fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
+fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<Option<Vec<TrashItem>>, Error> {
     trace!("Starting delete_using_file_mgr");
     let file_mgr = unsafe { NSFileManager::defaultManager() };
     for path in full_paths {
@@ -107,10 +106,10 @@ fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> 
             });
         }
     }
-    Ok(())
+    Ok(None)
 }
 
-fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
+fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<Option<Vec<TrashItem>>, Error> {
     // AppleScript command to move files (or directories) to Trash looks like
     //   osascript -e 'tell application "Finder" to delete { POSIX file "file1", POSIX "file2" }'
     // The `-e` flag is used to execute only one line of AppleScript.
@@ -150,7 +149,7 @@ fn delete_using_finder<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> {
             }
         };
     }
-    Ok(())
+    Ok(None)
 }
 
 /// std's from_utf8_lossy, but non-utf8 byte sequences are %-encoded instead of being replaced by a special symbol.

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -16,6 +16,7 @@ use crate::{into_unknown, Error, TrashContext, TrashItem};
 ///   | <br>Feature            |≝<br>Finder     |<br>NsFileManager |
 ///   |:-----------------------|:--------------:|:----------------:|
 ///   |Undo via "Put back"     | ✓              | ✗                |
+///   |Get trashed paths       | ✗              | ✓                |
 ///   |Speed                   | ✗<br>Slower    | ✓<br>Faster      |
 ///   |No sound                | ✗              | ✓                |
 ///   |No extra permissions    | ✗              | ✓                |
@@ -40,6 +41,7 @@ pub enum DeleteMethod {
     ///   at:
     ///   - <https://github.com/sindresorhus/macos-trash/issues/4>
     ///   - <https://github.com/ArturKovacs/trash-rs/issues/14>
+    /// - Allows getting the paths to the trashed items
     NsFileManager,
 }
 impl DeleteMethod {

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -189,7 +189,10 @@ fn delete_using_finder<P: AsRef<Path> + std::fmt::Debug>(
         "#
         )
     } else {
-        format!(r#"tell application "Finder" to delete {{ {posix_files} }}"#)
+        format!(
+            r#"tell application "Finder" to delete {{ {posix_files} }}
+                return "" "#
+        )
     };
     let mut script = Script::new_from_source(Language::AppleScript, &script_text);
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -83,7 +83,7 @@ impl TrashContext {
         with_info: bool,
     ) -> Result<Option<Vec<TrashItem>>, Error> {
         match self.platform_specific.delete_method {
-            DeleteMethod::Finder => delete_using_finder(&full_paths), //Finder doesn't return trashed paths
+            DeleteMethod::Finder => delete_using_finder(&full_paths), // TODO: parse Finder's output to get paths?
             DeleteMethod::NsFileManager => delete_using_file_mgr(&full_paths, with_info),
         }
     }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -7,7 +7,7 @@ use std::{
 use log::trace;
 use objc2_foundation::{NSFileManager, NSString, NSURL};
 
-use crate::{into_unknown, Error, TrashContext};
+use crate::{into_unknown, Error, TrashContext, TrashItem};
 
 #[derive(Copy, Clone, Debug)]
 /// There are 2 ways to trash files: via the ≝Finder app or via the OS NsFileManager call
@@ -74,11 +74,12 @@ impl TrashContextExtMacos for TrashContext {
     }
 }
 impl TrashContext {
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
+    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
         match self.platform_specific.delete_method {
-            DeleteMethod::Finder => delete_using_finder(&full_paths),
-            DeleteMethod::NsFileManager => delete_using_file_mgr(&full_paths),
+            DeleteMethod::Finder =>  delete_using_finder(&full_paths)?,
+            DeleteMethod::NsFileManager =>  delete_using_file_mgr(&full_paths)?,
         }
+        Ok(None)
     }
 }
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -179,7 +179,7 @@ fn delete_using_finder<P: AsRef<Path> + std::fmt::Debug>(
         tell application "Finder"
             set Trash_items to delete {{ {posix_files} }}
         end tell
-        if Trash_items is not list then -- if only 1 file is deleted, returns a file, not a list
+        if (class of Trash_items) is not list then -- if only 1 file is deleted, returns a file, not a list
             return                   (POSIX path of (Trash_items as alias))
         end if
         repeat with aFile in Trash_items -- Finder reference

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -33,6 +33,17 @@ fn test_delete_with_finder_with_info() {
         std::fs::remove_file(&trashed_path).unwrap(); // clean   up
         assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
     }
+
+    // test a single file (in case returned paths aren't an array anymore)
+    let mut path3 = PathBuf::from(get_unique_name());
+    path3.set_extension(r#"a"b,"#);
+    File::create_new(&path3).unwrap();
+    let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
+    assert!(File::open(&path3).is_err()); // original files deleted
+    let trashed_path = item.id;
+    assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+    std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+    assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
 }
 
 

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -24,14 +24,14 @@ fn test_delete_with_finder_with_info() {
     path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
     File::create_new(&path1).unwrap();
     File::create_new(&path2).unwrap();
-    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(),path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
     assert!(File::open(&path1).is_err()); // original files deleted
     assert!(File::open(&path2).is_err());
     for item in trashed_items {
         let trashed_path = item.id;
         assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
         std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-        assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
+        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
     }
 
     // test a single file (in case returned paths aren't an array anymore)
@@ -43,9 +43,8 @@ fn test_delete_with_finder_with_info() {
     let trashed_path = item.id;
     assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
     std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-    assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
+    assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
 }
-
 
 #[test]
 #[serial]
@@ -64,14 +63,14 @@ fn test_delete_binary_with_finder_with_info() {
     File::create_new(&path2).unwrap();
     assert!(&path1.exists());
     assert!(&path2.exists());
-    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(),path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
     assert!(File::open(&path1).is_err()); // original files deleted
     assert!(File::open(&path2).is_err());
     for item in trashed_items {
         let trashed_path = item.id;
         assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
         std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-        assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
+        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
     }
 }
 

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     canonicalize_paths,
-    macos::{percent_encode, DeleteMethod, TrashContextExtMacos},
+    macos::{percent_encode, DeleteMethod, ScriptMethod, TrashContextExtMacos},
     tests::{get_unique_name, init_logging},
     TrashContext,
 };
@@ -17,6 +17,7 @@ fn test_delete_with_finder_with_info() {
     init_logging();
     let mut trash_ctx = TrashContext::default();
     trash_ctx.set_delete_method(DeleteMethod::Finder);
+    trash_ctx.set_script_method(ScriptMethod::Cli);
 
     let mut path1 = PathBuf::from(get_unique_name());
     let mut path2 = PathBuf::from(get_unique_name());

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -47,43 +47,6 @@ fn test_delete_with_finder_with_info() {
     assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
 }
 
-/*
-#[test]
-#[serial]
-fn test_delete_with_finder_osakit_with_info() { // tested to work, but not always: can randomly timeout, so disabled by default
-    init_logging();
-    let mut trash_ctx = TrashContext::default();
-    trash_ctx.set_delete_method(DeleteMethod::Finder);
-    trash_ctx.set_script_method(ScriptMethod::Osakit);
-
-    let mut path1 = PathBuf::from(get_unique_name());
-    let mut path2 = PathBuf::from(get_unique_name());
-    path1.set_extension(r#"a"b,"#);
-    path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
-    File::create_new(&path1).unwrap();
-    File::create_new(&path2).unwrap();
-    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
-    assert!(File::open(&path1).is_err()); // original files deleted
-    assert!(File::open(&path2).is_err());
-    for item in trashed_items {
-        let trashed_path = item.id;
-        assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
-        std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
-    }
-
-    // test a single file (in case returned paths aren't an array anymore)
-    let mut path3 = PathBuf::from(get_unique_name());
-    path3.set_extension(r#"a"b,"#);
-    File::create_new(&path3).unwrap();
-    let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
-    assert!(File::open(&path3).is_err()); // original files deleted
-    let trashed_path = item.id;
-    assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
-    std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-    assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
-}*/
-
 #[test]
 #[serial]
 fn test_delete_binary_with_finder_with_info() {

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -107,6 +107,20 @@ fn test_delete_with_ns_file_manager() {
 
 #[test]
 #[serial]
+fn test_delete_with_finder() {
+    init_logging();
+    let mut trash_ctx = TrashContext::default();
+    trash_ctx.set_delete_method(DeleteMethod::Finder);
+
+    let path = PathBuf::from(get_unique_name());
+    File::create_new(&path).unwrap();
+    assert!(path.exists());
+    trash_ctx.delete(&path).unwrap();
+    assert!(!path.exists());
+}
+
+#[test]
+#[serial]
 fn test_delete_binary_path_with_ns_file_manager_with_info() {
     init_logging();
     let mut trash_ctx = TrashContext::default();

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -34,6 +34,33 @@ fn test_delete_with_finder_with_info() {
         assert!( File::open(&trashed_path).is_err()); // cleaned up trash items
     }
 }
+
+
+// #[test]
+// #[serial]
+// fn test_delete_with_finder_with_info_invalid() {
+//     // add invalid byt
+//     init_logging();
+//     let mut trash_ctx = TrashContext::default();
+//     trash_ctx.set_delete_method(DeleteMethod::Finder);
+
+//     let p = PathBuf::from("/Volumes/Untitled");
+
+//     let invalid_utf8 = b"\x80"; // lone continuation byte (128) (invalid utf8)
+
+//     let mut path1 = p.clone();
+//     let mut path2 = p.clone();
+//     path1.push(get_unique_name());
+//     path2.push(get_unique_name());
+//     path1.set_extension(OsStr::from_bytes(invalid_utf8));
+//     path2.set_extension(OsStr::from_bytes(invalid_utf8));
+
+//     File::create_new(&path1).unwrap();
+//     File::create_new(&path2).unwrap();
+//     trash_ctx.delete_all_with_info(&[path1,path2]).unwrap();
+//     // assert!(File::open(&path1).is_err());
+//     // assert!(File::open(&path2).is_err());
+// }
 #[test]
 #[serial]
 fn test_delete_with_finder_quoted_paths() {

--- a/src/macos/tests.rs
+++ b/src/macos/tests.rs
@@ -47,6 +47,43 @@ fn test_delete_with_finder_with_info() {
     assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
 }
 
+/*
+#[test]
+#[serial]
+fn test_delete_with_finder_osakit_with_info() { // tested to work, but not always: can randomly timeout, so disabled by default
+    init_logging();
+    let mut trash_ctx = TrashContext::default();
+    trash_ctx.set_delete_method(DeleteMethod::Finder);
+    trash_ctx.set_script_method(ScriptMethod::Osakit);
+
+    let mut path1 = PathBuf::from(get_unique_name());
+    let mut path2 = PathBuf::from(get_unique_name());
+    path1.set_extension(r#"a"b,"#);
+    path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
+    File::create_new(&path1).unwrap();
+    File::create_new(&path2).unwrap();
+    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+    assert!(File::open(&path1).is_err()); // original files deleted
+    assert!(File::open(&path2).is_err());
+    for item in trashed_items {
+        let trashed_path = item.id;
+        assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+        std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+    }
+
+    // test a single file (in case returned paths aren't an array anymore)
+    let mut path3 = PathBuf::from(get_unique_name());
+    path3.set_extension(r#"a"b,"#);
+    File::create_new(&path3).unwrap();
+    let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
+    assert!(File::open(&path3).is_err()); // original files deleted
+    let trashed_path = item.id;
+    assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+    std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+    assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+}*/
+
 #[test]
 #[serial]
 fn test_delete_binary_with_finder_with_info() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -74,7 +74,7 @@ impl TrashContext {
     }
 
     /// Removes all files and folder paths recursively.
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
+    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>, _with_info: bool) -> Result<Option<Vec<TrashItem>>, Error> {
         self.delete_specified_canonicalized(full_paths)
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -36,7 +36,10 @@ impl PlatformTrashContext {
 }
 impl TrashContext {
     /// See https://docs.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-_shfileopstructa
-    pub(crate) fn delete_specified_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
+    pub(crate) fn delete_specified_canonicalized(
+        &self,
+        full_paths: Vec<PathBuf>,
+    ) -> Result<Option<Vec<TrashItem>>, Error> {
         ensure_com_initialized();
         unsafe {
             let pfo: IFileOperation = CoCreateInstance(&FileOperation as *const _, None, CLSCTX_ALL).unwrap();
@@ -66,14 +69,13 @@ impl TrashContext {
                 // the list of HRESULT codes is not documented.
                 return Err(Error::Unknown { description: "Some operations were aborted".into() });
             }
-            Ok(())
+            Ok(None)
         }
     }
 
     /// Removes all files and folder paths recursively.
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<(), Error> {
-        self.delete_specified_canonicalized(full_paths)?;
-        Ok(())
+    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>) -> Result<Option<Vec<TrashItem>>, Error> {
+        self.delete_specified_canonicalized(full_paths)
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -74,7 +74,11 @@ impl TrashContext {
     }
 
     /// Removes all files and folder paths recursively.
-    pub(crate) fn delete_all_canonicalized(&self, full_paths: Vec<PathBuf>, _with_info: bool) -> Result<Option<Vec<TrashItem>>, Error> {
+    pub(crate) fn delete_all_canonicalized(
+        &self,
+        full_paths: Vec<PathBuf>,
+        _with_info: bool,
+    ) -> Result<Option<Vec<TrashItem>>, Error> {
         self.delete_specified_canonicalized(full_paths)
     }
 }

--- a/tests/osakit.rs
+++ b/tests/osakit.rs
@@ -1,5 +1,5 @@
-// Separate file to force running the tests on the main thread, required for any macOS OSAkit APIs, which otherwise fail after a 2-min stall
-// Uses cargo-nextest and a custom libtest_mimic test harness for that since the default Cargo test doesn't.
+// Separate file to force running tests on the main thread, a must for macOS OSAkit APIs, which can otherwise fail after a 2-min stall
+// Uses a custom libtest_mimic test harness for that since the default Cargo test doesn't support it.
 // ADD "test_main_thread_" prefix to test names so that the main cargo test run filter them out with `--skip "test_main_thread_"`
 fn main() {
     #[cfg(target_os = "macos")]

--- a/tests/osakit.rs
+++ b/tests/osakit.rs
@@ -9,11 +9,8 @@ use trash::{
     TrashContext,
 };
 use trash_tests::{get_unique_name, init_logging}; // not pub, so import directly
-// use std::ffi::OsStr;
-// use std::os::unix::ffi::OsStrExt;
 use std::fs::File;
 use std::path::PathBuf;
-// use std::process::Command;
 
 use libtest_mimic::{Arguments, Trial};
 #[ignore]
@@ -46,16 +43,19 @@ pub fn test_main_thread_delete_with_finder_osakit_with_info() {
     let mut path2 = PathBuf::from(get_unique_name());
     path1.set_extension(r#"a"b,"#);
     path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
-    File::create_new(&path1).unwrap();
-    File::create_new(&path2).unwrap();
-    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
-    assert!(File::open(&path1).is_err()); // original files deleted
-    assert!(File::open(&path2).is_err());
-    for item in trashed_items {
-        let trashed_path = item.id;
-        assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
-        std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+    for _i in 1..10 {
+        // run a few times since previously threading issues didn't always appear on 1st run
+        File::create_new(&path1).unwrap();
+        File::create_new(&path2).unwrap();
+        let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+        assert!(File::open(&path1).is_err()); // original files deleted
+        assert!(File::open(&path2).is_err());
+        for item in trashed_items {
+            let trashed_path = item.id;
+            assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+            std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+            assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+        }
     }
 
     // test a single file (in case returned paths aren't an array anymore)

--- a/tests/osakit.rs
+++ b/tests/osakit.rs
@@ -1,0 +1,49 @@
+// Separate file to force running the tests on the main thread, which is required for any macOS OSAkit APIs, which otherwise fail after a 2-min stall
+use trash::{
+    canonicalize_paths,
+    macos::{percent_encode, DeleteMethod, ScriptMethod, TrashContextExtMacos},
+    tests::{get_unique_name, init_logging},
+    TrashContext,
+};
+use serial_test::serial;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[test]
+#[serial]
+fn test_delete_with_finder_osakit_with_info() { // tested to work, but not always: can randomly timeout, so disabled by default
+    init_logging();
+    let mut trash_ctx = TrashContext::default();
+    trash_ctx.set_delete_method(DeleteMethod::Finder);
+    trash_ctx.set_script_method(ScriptMethod::Osakit);
+
+    let mut path1 = PathBuf::from(get_unique_name());
+    let mut path2 = PathBuf::from(get_unique_name());
+    path1.set_extension(r#"a"b,"#);
+    path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
+    File::create_new(&path1).unwrap();
+    File::create_new(&path2).unwrap();
+    let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+    assert!(File::open(&path1).is_err()); // original files deleted
+    assert!(File::open(&path2).is_err());
+    for item in trashed_items {
+        let trashed_path = item.id;
+        assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+        std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+    }
+
+    // test a single file (in case returned paths aren't an array anymore)
+    let mut path3 = PathBuf::from(get_unique_name());
+    path3.set_extension(r#"a"b,"#);
+    File::create_new(&path3).unwrap();
+    let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
+    assert!(File::open(&path3).is_err()); // original files deleted
+    let trashed_path = item.id;
+    assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+    std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+    assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+}

--- a/tests/osakit.rs
+++ b/tests/osakit.rs
@@ -38,7 +38,7 @@ mod test_main_thread_mac {
         // OSAkit must be run on the main thread
         if let Some("main") = thread::current().name() {
         } else {
-            eprintln!("This test is NOT thread-safe, so must be run on the main thread, and is not, thus can fail…");
+            panic!("OSAkit is NOT thread-safe, so this test must run on the main thread, and it's not");
         };
 
         init_logging();

--- a/tests/osakit.rs
+++ b/tests/osakit.rs
@@ -1,71 +1,79 @@
 // Separate file to force running the tests on the main thread, required for any macOS OSAkit APIs, which otherwise fail after a 2-min stall
 // Uses cargo-nextest and a custom libtest_mimic test harness for that since the default Cargo test doesn't.
 // ADD "test_main_thread_" prefix to test names so that the main cargo test run filter them out with `--skip "test_main_thread_"`
-#[path = "../src/tests.rs"]
-mod trash_tests;
-use serial_test::serial;
-use trash::{
-    macos::{DeleteMethod, ScriptMethod, TrashContextExtMacos},
-    TrashContext,
-};
-use trash_tests::{get_unique_name, init_logging}; // not pub, so import directly
-use std::fs::File;
-use std::path::PathBuf;
-
-use libtest_mimic::{Arguments, Trial};
-#[ignore]
 fn main() {
-    let args = Arguments::from_args(); // Parse command line arguments
-    let tests = vec![
-        // Create a list of tests and/or benchmarks
-        Trial::test("test_main_thread_delete_with_finder_osakit_with_info", || {
-            Ok(test_main_thread_delete_with_finder_osakit_with_info())
-        }),
-    ];
-    libtest_mimic::run(&args, tests).exit(); // Run all tests and exit the application appropriatly
+    #[cfg(target_os = "macos")]
+    test_main_thread_mac::main_mac()
 }
 
-use std::thread;
-#[serial]
-pub fn test_main_thread_delete_with_finder_osakit_with_info() {
-    // OSAkit must be run on the main thread
-    if let Some("main") = thread::current().name() {
-    } else {
-        eprintln!("This test is NOT thread-safe, so must be run on the main thread, and is not, thus can fail…");
-    };
+#[cfg(target_os = "macos")]
+#[path = "../src/tests.rs"]
+mod trash_tests;
 
-    init_logging();
-    let mut trash_ctx = TrashContext::default();
-    trash_ctx.set_delete_method(DeleteMethod::Finder);
-    trash_ctx.set_script_method(ScriptMethod::Osakit);
+#[cfg(target_os = "macos")]
+mod test_main_thread_mac {
+    use crate::trash_tests::{get_unique_name, init_logging};
+    use serial_test::serial;
+    use std::{fs::File, path::PathBuf};
+    use trash::{
+        macos::{DeleteMethod, ScriptMethod, TrashContextExtMacos},
+        TrashContext,
+    }; // not pub, so import directly
 
-    let mut path1 = PathBuf::from(get_unique_name());
-    let mut path2 = PathBuf::from(get_unique_name());
-    path1.set_extension(r#"a"b,"#);
-    path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
-    for _i in 1..10 {
-        // run a few times since previously threading issues didn't always appear on 1st run
-        File::create_new(&path1).unwrap();
-        File::create_new(&path2).unwrap();
-        let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
-        assert!(File::open(&path1).is_err()); // original files deleted
-        assert!(File::open(&path2).is_err());
-        for item in trashed_items {
-            let trashed_path = item.id;
-            assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
-            std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-            assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
-        }
+    pub(crate) fn main_mac() {
+        use libtest_mimic::{Arguments, Trial};
+        let args = Arguments::from_args(); // Parse command line arguments
+        let tests = vec![
+            // Create a list of tests and/or benchmarks
+            Trial::test("test_main_thread_delete_with_finder_osakit_with_info", || {
+                Ok(test_main_thread_delete_with_finder_osakit_with_info())
+            }),
+        ];
+        libtest_mimic::run(&args, tests).exit(); // Run all tests and exit the application appropriatly
     }
 
-    // test a single file (in case returned paths aren't an array anymore)
-    let mut path3 = PathBuf::from(get_unique_name());
-    path3.set_extension(r#"a"b,"#);
-    File::create_new(&path3).unwrap();
-    let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
-    assert!(File::open(&path3).is_err()); // original files deleted
-    let trashed_path = item.id;
-    assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
-    std::fs::remove_file(&trashed_path).unwrap(); // clean   up
-    assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+    use std::thread;
+    #[serial]
+    pub fn test_main_thread_delete_with_finder_osakit_with_info() {
+        // OSAkit must be run on the main thread
+        if let Some("main") = thread::current().name() {
+        } else {
+            eprintln!("This test is NOT thread-safe, so must be run on the main thread, and is not, thus can fail…");
+        };
+
+        init_logging();
+        let mut trash_ctx = TrashContext::default();
+        trash_ctx.set_delete_method(DeleteMethod::Finder);
+        trash_ctx.set_script_method(ScriptMethod::Osakit);
+
+        let mut path1 = PathBuf::from(get_unique_name());
+        let mut path2 = PathBuf::from(get_unique_name());
+        path1.set_extension(r#"a"b,"#);
+        path2.set_extension(r#"x80=%80 slash=\ pc=% quote=" comma=,"#);
+        for _i in 1..10 {
+            // run a few times since previously threading issues didn't always appear on 1st run
+            File::create_new(&path1).unwrap();
+            File::create_new(&path2).unwrap();
+            let trashed_items = trash_ctx.delete_all_with_info(&[path1.clone(), path2.clone()]).unwrap().unwrap(); //Ok + Some trashed paths
+            assert!(File::open(&path1).is_err()); // original files deleted
+            assert!(File::open(&path2).is_err());
+            for item in trashed_items {
+                let trashed_path = item.id;
+                assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+                std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+                assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+            }
+        }
+
+        // test a single file (in case returned paths aren't an array anymore)
+        let mut path3 = PathBuf::from(get_unique_name());
+        path3.set_extension(r#"a"b,"#);
+        File::create_new(&path3).unwrap();
+        let item = trash_ctx.delete_with_info(&path3).unwrap().unwrap(); //Ok + Some trashed paths
+        assert!(File::open(&path3).is_err()); // original files deleted
+        let trashed_path = item.id;
+        assert!(!File::open(&trashed_path).is_err()); // returned trash items exist
+        std::fs::remove_file(&trashed_path).unwrap(); // clean   up
+        assert!(File::open(&trashed_path).is_err()); // cleaned up trash items
+    }
 }


### PR DESCRIPTION
Builds upon the previous Linux PR for easier rebasing, will add comment to the existing PR not to split the discussion

https://github.com/Byron/trash-rs/pull/109

- add macos functions that return trashed items: **optionally** if called via `_with_info` functions (for both Finder with AppleScript and FS API), so there is no mandatory overhead for long lists
  - ✗ couldn't find a way to get OS trash timestamp even though it exists (Finders knows it, but the metadata field is returned empty for us, maybe this is also hidden in DSStore???), so using the same logic of calculating our own timestamps like for Linux
- added a few tests for both trash types (though only checking return item's name/parent as time/path@trash can be inconsistent, so no guaranteed way for us to compare them)
- added **stub** `with_info` function arguments for Linux/Win, but the actual logic is **not implemented**

- added the new configurable faster/better method of launching AppleScript via direct Objc bindings to the automation kit, think it should be the **new default**, but for now left the old method (via separate proc) as the default.
  - Although stdout is eating quotation marks separating paths, so had to manually insert ` /// ` as list separators:
    -  ?: can there be a "natural" path that contains ` /// `, meaning this is a buggy separator?
