### PR TITLE
Prepare for `objc2` frameworks v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ defer = "0.2.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", features = [
+objc2-foundation = { version = "0.2.0", default-features = false, features = [
+    "std",
     "NSError",
     "NSFileManager",
     "NSString",


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).