### PR TITLE
Use octal for S_ISVTX sticky bit check

### DIFF
--- a/src/freedesktop.rs
+++ b/src/freedesktop.rs
@@ -611,7 +611,7 @@ enum TrashValidity {
 fn folder_validity(path: impl AsRef<Path>) -> Result<TrashValidity, FsError> {
     /// Mask for the sticky bit
     /// Taken from: http://man7.org/linux/man-pages/man7/inode.7.html
-    const S_ISVTX: u32 = 0x1000;
+    const S_ISVTX: u32 = 0o1000;
 
     let path = path.as_ref();
     let metadata = path.symlink_metadata().map_err(|e| (path.to_owned(), e))?;


### PR DESCRIPTION
Fixes the value of S_ISVTX to use octal `0o1000` instead of hexadecimal `0x1000` (= `0o10000`) in `folder_validity`.

I found this because I was unable to trash files in some mounted drives. This change fixes the issue.

This is some pretty old code and I'm a little surprised nobody noticed until now, so let me know if I'm missing something here. This doesn't affect "home" trash directories as they aren't validated by this, which may explain some of it, but does affect trash directories in other mount points.