### PR TITLE
mac: upgrade objc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ defer = "0.2.1"
 
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.5.1"
-objc2-foundation = { version = "0.2.0", default-features = false, features = [
+objc2 = "0.6.2"
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "NSError",
     "NSFileManager",

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -102,7 +102,7 @@ fn delete_using_file_mgr<P: AsRef<Path>>(full_paths: &[P]) -> Result<(), Error> 
 
         if let Err(err) = res {
             return Err(Error::Unknown {
-                description: format!("While deleting '{:?}', `trashItemAtURL` failed: {err}", path.as_ref()),
+                description: format!("While deleting '{:?}', `trashItemAtURL` failed: {err}", &path),
             });
         }
     }


### PR DESCRIPTION
Hello there! Thanks for this crate.

Please review this very tiny change: upgrading the objc2 version.
The old version breaks compatibility with some other crates.